### PR TITLE
#21 — LLM provider abstraction layer with decision logging

### DIFF
--- a/backend/llm/__init__.py
+++ b/backend/llm/__init__.py
@@ -1,0 +1,37 @@
+"""
+backend/llm/ — LLM provider abstraction layer.
+
+This package provides a single interface for calling any supported LLM provider
+(Anthropic Claude, OpenAI GPT, etc.) without the agent code knowing or caring
+which provider is being used.
+
+Architecture (see REQUIREMENTS.md §2.5):
+    Agents call `call_llm()` from `backend.llm.client`. That function:
+    1. Selects the provider based on config (default or per-agent override)
+    2. Checks daily/monthly cost caps before making the call (C5)
+    3. Delegates to the provider-specific implementation
+    4. Logs the call to the `agent_calls` table (C4 — full traceability)
+    5. Returns a unified response object
+
+Supported providers:
+    - Anthropic (Claude Sonnet 4.6, etc.) via `anthropic_provider.py`
+    - OpenAI (GPT-4o, GPT-4.1, etc.) via `openai_provider.py`
+
+Adding a new provider:
+    1. Create `backend/llm/new_provider.py` implementing `LLMProvider`
+    2. Add its pricing to `pricing.py`
+    3. Register it in `client.py` PROVIDERS dict
+    No agent code changes needed.
+
+Key modules:
+    provider.py            — Abstract base class `LLMProvider`
+    anthropic_provider.py  — Anthropic implementation
+    openai_provider.py     — OpenAI implementation
+    client.py              — Main `call_llm()` function (the only thing agents import)
+    pricing.py             — Per-model cost-per-token lookup
+    cost_tracker.py        — Queries agent_calls for daily/monthly spend
+"""
+
+from backend.llm.client import call_llm  # noqa: F401 — public API
+
+__all__ = ["call_llm"]

--- a/backend/llm/anthropic_provider.py
+++ b/backend/llm/anthropic_provider.py
@@ -1,0 +1,124 @@
+"""
+backend/llm/anthropic_provider.py — Anthropic Claude provider implementation.
+
+Wraps the Anthropic Python SDK to implement the LLMProvider interface.
+Supports tool-use (function calling) for structured extraction.
+
+This module is never imported directly by agents — they use `call_llm()`
+from `backend.llm.client`, which selects the provider based on config.
+
+Requires: ANTHROPIC_API_KEY environment variable.
+"""
+
+import os
+
+import anthropic
+
+from backend.llm.provider import (
+    LLMProvider,
+    LLMProviderError,
+    LLMRateLimitError,
+    LLMResponse,
+    LLMTimeoutError,
+    ToolDefinition,
+)
+
+
+class AnthropicProvider(LLMProvider):
+    """
+    Anthropic Claude implementation of the LLM provider interface.
+
+    Uses the Anthropic Python SDK for API calls. Converts our provider-agnostic
+    ToolDefinition objects to Anthropic's tool-use format, and converts
+    Anthropic's response back to our unified LLMResponse.
+    """
+
+    def __init__(self):
+        """
+        Initialize the Anthropic client.
+
+        Reads ANTHROPIC_API_KEY from environment. The SDK handles this
+        automatically, but we check explicitly to give a clear error message.
+        """
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise LLMProviderError(
+                "ANTHROPIC_API_KEY not set. Add it to .env or set the environment variable."
+            )
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    def call(
+        self,
+        model: str,
+        system_prompt: str | None,
+        user_prompt: str,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> LLMResponse:
+        """
+        Make a single Anthropic Claude API call.
+
+        Converts ToolDefinition objects to Anthropic's native tool format,
+        makes the call, and converts the response to LLMResponse.
+
+        See LLMProvider.call() for full argument documentation.
+        """
+        try:
+            # Build the messages list — Anthropic uses a messages array
+            messages = [{"role": "user", "content": user_prompt}]
+
+            # Build kwargs for the API call
+            kwargs = {
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+
+            # Add system prompt if provided (Anthropic takes it as a top-level param)
+            if system_prompt:
+                kwargs["system"] = system_prompt
+
+            # Convert our ToolDefinition objects to Anthropic's tool format
+            if tools:
+                kwargs["tools"] = [
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.input_schema,
+                    }
+                    for tool in tools
+                ]
+
+            # Make the API call
+            response = self.client.messages.create(**kwargs)
+
+            # Extract text content and tool-use results from the response.
+            # Anthropic returns a list of content blocks — some are text, some are tool_use.
+            text_parts = []
+            tool_calls = []
+            for block in response.content:
+                if block.type == "text":
+                    text_parts.append(block.text)
+                elif block.type == "tool_use":
+                    tool_calls.append({
+                        "name": block.name,
+                        "input": block.input,
+                    })
+
+            return LLMResponse(
+                content="\n".join(text_parts) if text_parts else None,
+                tool_calls=tool_calls,
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                model=response.model,
+                raw_response=response,
+            )
+
+        except anthropic.APITimeoutError as e:
+            raise LLMTimeoutError(f"Anthropic API timeout: {e}") from e
+        except anthropic.RateLimitError as e:
+            raise LLMRateLimitError(f"Anthropic rate limit: {e}") from e
+        except anthropic.APIError as e:
+            raise LLMProviderError(f"Anthropic API error: {e}") from e

--- a/backend/llm/client.py
+++ b/backend/llm/client.py
@@ -1,0 +1,260 @@
+"""
+backend/llm/client.py — Main LLM call function. This is the only thing agents import.
+
+`call_llm()` is the single entry point for every LLM interaction in the system.
+It handles provider selection, cost cap enforcement (C5), API call delegation,
+error handling, and logging every call to the `agent_calls` table (C4).
+
+Usage by agents:
+    from backend.llm import call_llm
+
+    response = call_llm(
+        db=db,
+        run_id=current_run.id,
+        agent_name="extraction",
+        system_prompt="Extract freight RFQ fields from this email...",
+        user_prompt=email_body,
+        tools=[extract_rfq_tool],
+    )
+    # response.tool_calls[0]["input"] has the extracted fields
+
+See REQUIREMENTS.md §2.5 for the architectural rationale.
+See NFR-OB-1 for the cost accuracy requirement (within 1% of actual bill).
+"""
+
+import logging
+import os
+import time
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import AgentCall, AgentCallStatus
+from backend.llm.anthropic_provider import AnthropicProvider
+from backend.llm.cost_tracker import check_cost_cap
+from backend.llm.openai_provider import OpenAIProvider
+from backend.llm.pricing import calculate_cost
+from backend.llm.provider import (
+    LLMCostCapExceeded,
+    LLMProvider,
+    LLMProviderError,
+    LLMRateLimitError,
+    LLMResponse,
+    LLMTimeoutError,
+    ToolDefinition,
+)
+
+logger = logging.getLogger("golteris.llm")
+
+# ---------------------------------------------------------------------------
+# Provider registry — maps provider name to its class.
+# Adding a new provider: implement LLMProvider, add it here.
+# ---------------------------------------------------------------------------
+
+PROVIDER_CLASSES: dict[str, type[LLMProvider]] = {
+    "anthropic": AnthropicProvider,
+    "openai": OpenAIProvider,
+}
+
+# Provider instances are cached after first use (one instance per provider).
+# This avoids creating a new SDK client on every call.
+_provider_instances: dict[str, LLMProvider] = {}
+
+
+def _get_provider(provider_name: str) -> LLMProvider:
+    """
+    Get or create a provider instance by name.
+
+    Caches instances so the SDK client is only initialized once per provider.
+    Raises LLMProviderError if the provider name is unknown or if the
+    provider's API key is not set.
+    """
+    if provider_name not in _provider_instances:
+        if provider_name not in PROVIDER_CLASSES:
+            raise LLMProviderError(
+                f"Unknown LLM provider '{provider_name}'. "
+                f"Available: {', '.join(sorted(PROVIDER_CLASSES.keys()))}"
+            )
+        # This will raise if the API key is missing — the provider __init__ checks
+        _provider_instances[provider_name] = PROVIDER_CLASSES[provider_name]()
+    return _provider_instances[provider_name]
+
+
+def _get_default_provider() -> str:
+    """Read the default provider from environment. Falls back to 'anthropic'."""
+    return os.environ.get("LLM_DEFAULT_PROVIDER", "anthropic")
+
+
+def _get_default_model() -> str:
+    """Read the default model from environment. Falls back to 'claude-sonnet-4-6'."""
+    return os.environ.get("LLM_DEFAULT_MODEL", "claude-sonnet-4-6")
+
+
+def call_llm(
+    db: Session,
+    run_id: int,
+    agent_name: str,
+    user_prompt: str,
+    system_prompt: str | None = None,
+    tools: list[ToolDefinition] | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    max_tokens: int = 4096,
+    temperature: float = 0.0,
+) -> LLMResponse:
+    """
+    Make an LLM API call with full logging and cost cap enforcement.
+
+    This is the ONLY function agents should use to call an LLM. It:
+    1. Checks cost caps (C5) — raises LLMCostCapExceeded if exceeded
+    2. Calls the selected provider
+    3. Calculates cost from token usage
+    4. Logs the call to `agent_calls` table (C4 — full traceability)
+    5. Returns a unified LLMResponse
+
+    Args:
+        db: SQLAlchemy session (for cost cap check and logging)
+        run_id: The parent agent_run ID (links this call to its workflow run)
+        agent_name: Which agent is making this call (e.g., "extraction", "validation")
+        user_prompt: The user message / input to process
+        system_prompt: System-level instructions (optional)
+        tools: Optional list of tools for structured extraction
+        provider: Provider name override (default: LLM_DEFAULT_PROVIDER env var)
+        model: Model override (default: LLM_DEFAULT_MODEL env var)
+        max_tokens: Maximum output tokens (default 4096)
+        temperature: Sampling temperature (default 0.0 for deterministic)
+
+    Returns:
+        LLMResponse with content, tool_calls, token counts, and raw response
+
+    Raises:
+        LLMCostCapExceeded: Daily or monthly cap exceeded (C5)
+        LLMTimeoutError: API call timed out
+        LLMRateLimitError: Provider rate limit hit
+        LLMProviderError: Any other provider-side error
+    """
+    # Resolve provider and model — use defaults if not overridden
+    provider_name = provider or _get_default_provider()
+    model_name = model or _get_default_model()
+
+    # C5: Check cost caps before making the call.
+    # This queries agent_calls for today's and this month's total spend.
+    check_cost_cap(db)
+
+    # Get the provider instance (cached after first use)
+    llm_provider = _get_provider(provider_name)
+
+    # Record the start time for duration tracking
+    started_at = datetime.utcnow()
+    start_time = time.monotonic()
+
+    # Pre-create the agent_calls row with status=running so it's visible
+    # in the Agent → Decisions view even while the call is in progress.
+    # We'll update it with the result when the call completes.
+    call_record = AgentCall(
+        run_id=run_id,
+        agent_name=agent_name,
+        provider=provider_name,
+        model=model_name,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=Decimal("0"),
+        started_at=started_at,
+        status=AgentCallStatus.SUCCESS,  # optimistic — updated on failure
+    )
+    db.add(call_record)
+    db.flush()  # get the ID without committing
+
+    try:
+        # Make the actual LLM call via the provider
+        response = llm_provider.call(
+            model=model_name,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        # Calculate duration
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        finished_at = datetime.utcnow()
+
+        # Calculate cost (NFR-OB-1 — must match actual bill within 1%)
+        cost_usd = calculate_cost(model_name, response.input_tokens, response.output_tokens)
+
+        # Update the call record with results
+        call_record.input_tokens = response.input_tokens
+        call_record.output_tokens = response.output_tokens
+        call_record.cost_usd = Decimal(str(round(cost_usd, 6)))
+        call_record.finished_at = finished_at
+        call_record.duration_ms = duration_ms
+        call_record.status = AgentCallStatus.SUCCESS
+        # Store the response as text for the "View system reasoning" disclosure.
+        # For tool-use, this is the JSON representation of the tool calls.
+        call_record.response = str(response.raw_response)
+
+        db.commit()
+
+        logger.info(
+            "LLM call: agent=%s provider=%s model=%s tokens=%d/%d cost=$%.4f duration=%dms",
+            agent_name, provider_name, model_name,
+            response.input_tokens, response.output_tokens,
+            cost_usd, duration_ms,
+        )
+
+        return response
+
+    except LLMTimeoutError as e:
+        # Log the timeout in the call record
+        _record_failure(db, call_record, start_time, AgentCallStatus.TIMEOUT, str(e))
+        raise
+
+    except LLMRateLimitError as e:
+        # Log the rate limit in the call record
+        _record_failure(db, call_record, start_time, AgentCallStatus.RATE_LIMITED, str(e))
+        raise
+
+    except (LLMProviderError, Exception) as e:
+        # Log any other failure in the call record
+        _record_failure(db, call_record, start_time, AgentCallStatus.FAILED, str(e))
+        if isinstance(e, LLMProviderError):
+            raise
+        raise LLMProviderError(f"Unexpected error in LLM call: {e}") from e
+
+
+def _record_failure(
+    db: Session,
+    call_record: AgentCall,
+    start_time: float,
+    status: AgentCallStatus,
+    error_message: str,
+) -> None:
+    """
+    Update an agent_calls record with failure details and commit.
+
+    Called when the LLM call fails for any reason (timeout, rate limit, error).
+    Ensures the failure is recorded in the database for the Agent → Decisions view
+    and for error monitoring.
+    """
+    duration_ms = int((time.monotonic() - start_time) * 1000)
+    call_record.finished_at = datetime.utcnow()
+    call_record.duration_ms = duration_ms
+    call_record.status = status
+    call_record.error_message = error_message
+
+    try:
+        db.commit()
+    except Exception:
+        # If the commit fails (e.g., DB connection lost), log and swallow —
+        # we don't want a logging failure to mask the original LLM error.
+        logger.exception("Failed to record LLM call failure to database")
+        db.rollback()
+
+    logger.error(
+        "LLM call failed: agent=%s status=%s duration=%dms error=%s",
+        call_record.agent_name, status.value, duration_ms, error_message,
+    )

--- a/backend/llm/cost_tracker.py
+++ b/backend/llm/cost_tracker.py
@@ -1,0 +1,104 @@
+"""
+backend/llm/cost_tracker.py — Tracks LLM spend against daily/monthly cost caps.
+
+C5 enforcement: before every LLM call, `client.py` calls `check_cost_cap()`
+to verify the daily and monthly spend limits haven't been exceeded. If they
+have, `LLMCostCapExceeded` is raised and no call is made.
+
+Cost caps are configured via environment variables:
+    LLM_DAILY_COST_CAP  — max USD per day (default $20)
+    LLM_MONTHLY_COST_CAP — max USD per month (default $100)
+
+These apply across ALL providers combined (Anthropic + OpenAI + any others).
+"""
+
+import os
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.db.models import AgentCall
+from backend.llm.provider import LLMCostCapExceeded
+
+
+def get_daily_spend(db: Session) -> Decimal:
+    """
+    Sum of cost_usd for all agent_calls created today (UTC).
+
+    Returns:
+        Total spend today in USD as a Decimal.
+    """
+    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    result = db.query(func.coalesce(func.sum(AgentCall.cost_usd), 0)).filter(
+        AgentCall.started_at >= today_start
+    ).scalar()
+    return Decimal(str(result))
+
+
+def get_monthly_spend(db: Session) -> Decimal:
+    """
+    Sum of cost_usd for all agent_calls created this calendar month (UTC).
+
+    Returns:
+        Total spend this month in USD as a Decimal.
+    """
+    month_start = datetime.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    result = db.query(func.coalesce(func.sum(AgentCall.cost_usd), 0)).filter(
+        AgentCall.started_at >= month_start
+    ).scalar()
+    return Decimal(str(result))
+
+
+def get_cost_caps() -> tuple[Decimal, Decimal]:
+    """
+    Read cost caps from environment variables.
+
+    Returns:
+        (daily_cap, monthly_cap) as Decimals in USD.
+        Falls back to $20/day and $100/month if not set.
+    """
+    # Support both old ANTHROPIC_ prefix and new LLM_ prefix for backwards compat
+    daily = os.environ.get(
+        "LLM_DAILY_COST_CAP",
+        os.environ.get("ANTHROPIC_DAILY_COST_CAP", "20.00")
+    )
+    monthly = os.environ.get(
+        "LLM_MONTHLY_COST_CAP",
+        os.environ.get("ANTHROPIC_MONTHLY_COST_CAP", "100.00")
+    )
+    return Decimal(daily), Decimal(monthly)
+
+
+def check_cost_cap(db: Session) -> None:
+    """
+    Check if the daily or monthly cost cap has been exceeded.
+
+    C5 enforcement point — called before every LLM call in `client.py`.
+    If either cap is exceeded, raises `LLMCostCapExceeded` and the call
+    is not made.
+
+    Args:
+        db: SQLAlchemy session for querying agent_calls
+
+    Raises:
+        LLMCostCapExceeded: If daily or monthly cap is exceeded.
+            The exception message includes the current spend and the cap,
+            so operators can see exactly why the cap was hit.
+    """
+    daily_cap, monthly_cap = get_cost_caps()
+    daily_spend = get_daily_spend(db)
+    monthly_spend = get_monthly_spend(db)
+
+    if daily_spend >= daily_cap:
+        raise LLMCostCapExceeded(
+            f"Daily LLM cost cap exceeded: ${daily_spend:.2f} spent today "
+            f"(cap: ${daily_cap:.2f}). No further LLM calls until tomorrow."
+        )
+
+    if monthly_spend >= monthly_cap:
+        raise LLMCostCapExceeded(
+            f"Monthly LLM cost cap exceeded: ${monthly_spend:.2f} spent this month "
+            f"(cap: ${monthly_cap:.2f}). No further LLM calls until next month."
+        )

--- a/backend/llm/openai_provider.py
+++ b/backend/llm/openai_provider.py
@@ -1,0 +1,131 @@
+"""
+backend/llm/openai_provider.py — OpenAI GPT provider implementation.
+
+Wraps the OpenAI Python SDK to implement the LLMProvider interface.
+Supports function calling (tool-use) for structured extraction.
+
+This module is never imported directly by agents — they use `call_llm()`
+from `backend.llm.client`, which selects the provider based on config.
+
+Requires: OPENAI_API_KEY environment variable.
+"""
+
+import json
+import os
+
+import openai
+
+from backend.llm.provider import (
+    LLMProvider,
+    LLMProviderError,
+    LLMRateLimitError,
+    LLMResponse,
+    LLMTimeoutError,
+    ToolDefinition,
+)
+
+
+class OpenAIProvider(LLMProvider):
+    """
+    OpenAI GPT implementation of the LLM provider interface.
+
+    Uses the OpenAI Python SDK for API calls. Converts our provider-agnostic
+    ToolDefinition objects to OpenAI's function calling format, and converts
+    OpenAI's response back to our unified LLMResponse.
+    """
+
+    def __init__(self):
+        """
+        Initialize the OpenAI client.
+
+        Reads OPENAI_API_KEY from environment.
+        """
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise LLMProviderError(
+                "OPENAI_API_KEY not set. Add it to .env or set the environment variable."
+            )
+        self.client = openai.OpenAI(api_key=api_key)
+
+    def call(
+        self,
+        model: str,
+        system_prompt: str | None,
+        user_prompt: str,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> LLMResponse:
+        """
+        Make a single OpenAI API call.
+
+        Converts ToolDefinition objects to OpenAI's function calling format,
+        makes the call, and converts the response to LLMResponse.
+
+        See LLMProvider.call() for full argument documentation.
+        """
+        try:
+            # Build messages — OpenAI uses a messages array with role-based entries
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            messages.append({"role": "user", "content": user_prompt})
+
+            # Build kwargs for the API call
+            kwargs = {
+                "model": model,
+                "messages": messages,
+                "max_completion_tokens": max_tokens,
+                "temperature": temperature,
+            }
+
+            # Convert our ToolDefinition objects to OpenAI's function format.
+            # OpenAI wraps each function in a {"type": "function", "function": {...}} object.
+            if tools:
+                kwargs["tools"] = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": tool.input_schema,
+                        },
+                    }
+                    for tool in tools
+                ]
+
+            # Make the API call
+            response = self.client.chat.completions.create(**kwargs)
+
+            # Extract content and tool calls from the response
+            choice = response.choices[0]
+            message = choice.message
+
+            # Text content
+            content = message.content
+
+            # Tool calls — OpenAI returns these as a list on the message object
+            tool_calls = []
+            if message.tool_calls:
+                for tc in message.tool_calls:
+                    # OpenAI returns function arguments as a JSON string — parse it
+                    tool_calls.append({
+                        "name": tc.function.name,
+                        "input": json.loads(tc.function.arguments),
+                    })
+
+            return LLMResponse(
+                content=content,
+                tool_calls=tool_calls,
+                input_tokens=response.usage.prompt_tokens,
+                output_tokens=response.usage.completion_tokens,
+                model=response.model,
+                raw_response=response,
+            )
+
+        except openai.APITimeoutError as e:
+            raise LLMTimeoutError(f"OpenAI API timeout: {e}") from e
+        except openai.RateLimitError as e:
+            raise LLMRateLimitError(f"OpenAI rate limit: {e}") from e
+        except openai.APIError as e:
+            raise LLMProviderError(f"OpenAI API error: {e}") from e

--- a/backend/llm/pricing.py
+++ b/backend/llm/pricing.py
@@ -1,0 +1,108 @@
+"""
+backend/llm/pricing.py — Per-model cost-per-token lookup.
+
+Used by client.py to calculate the cost of each LLM call in USD.
+Cost must match the provider's actual bill within 1% (NFR-OB-1).
+
+Prices are in USD per token (not per 1K or 1M tokens) for simpler math.
+Update this file when providers change pricing.
+
+Sources:
+    Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
+    OpenAI: https://platform.openai.com/docs/models
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ModelPricing:
+    """
+    Cost per token for a specific model.
+
+    Attributes:
+        input_cost_per_token: USD cost per input token
+        output_cost_per_token: USD cost per output token
+    """
+    input_cost_per_token: float
+    output_cost_per_token: float
+
+
+# ---------------------------------------------------------------------------
+# Pricing table — update when providers change prices
+#
+# Format: "model_id" → ModelPricing(input, output)
+# Prices are per-token in USD (divide provider's per-million price by 1,000,000)
+# ---------------------------------------------------------------------------
+
+MODEL_PRICING: dict[str, ModelPricing] = {
+    # --- Anthropic Claude ---
+    # Claude Opus 4.6: $15/M input, $75/M output
+    "claude-opus-4-6": ModelPricing(
+        input_cost_per_token=15.0 / 1_000_000,
+        output_cost_per_token=75.0 / 1_000_000,
+    ),
+    # Claude Sonnet 4.6: $3/M input, $15/M output
+    "claude-sonnet-4-6": ModelPricing(
+        input_cost_per_token=3.0 / 1_000_000,
+        output_cost_per_token=15.0 / 1_000_000,
+    ),
+    # Claude Haiku 4.5: $0.80/M input, $4/M output
+    "claude-haiku-4-5-20251001": ModelPricing(
+        input_cost_per_token=0.80 / 1_000_000,
+        output_cost_per_token=4.0 / 1_000_000,
+    ),
+
+    # --- OpenAI GPT ---
+    # GPT-4o: $2.50/M input, $10/M output
+    "gpt-4o": ModelPricing(
+        input_cost_per_token=2.50 / 1_000_000,
+        output_cost_per_token=10.0 / 1_000_000,
+    ),
+    # GPT-4.1: $2/M input, $8/M output
+    "gpt-4.1": ModelPricing(
+        input_cost_per_token=2.0 / 1_000_000,
+        output_cost_per_token=8.0 / 1_000_000,
+    ),
+    # GPT-4.1-mini: $0.40/M input, $1.60/M output
+    "gpt-4.1-mini": ModelPricing(
+        input_cost_per_token=0.40 / 1_000_000,
+        output_cost_per_token=1.60 / 1_000_000,
+    ),
+    # GPT-4.1-nano: $0.10/M input, $0.40/M output
+    "gpt-4.1-nano": ModelPricing(
+        input_cost_per_token=0.10 / 1_000_000,
+        output_cost_per_token=0.40 / 1_000_000,
+    ),
+}
+
+
+def calculate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    """
+    Calculate the cost of an LLM call in USD.
+
+    Args:
+        model: The model identifier (must be in MODEL_PRICING)
+        input_tokens: Number of input tokens consumed
+        output_tokens: Number of output tokens generated
+
+    Returns:
+        Cost in USD as a float (e.g., 0.00435)
+
+    Raises:
+        KeyError: If the model is not in the pricing table. This is intentional —
+                  we want to fail loudly if an unknown model is used, rather than
+                  silently logging $0.00 costs that would make the cost caps useless.
+    """
+    if model not in MODEL_PRICING:
+        raise KeyError(
+            f"Model '{model}' not found in pricing table. "
+            f"Add it to backend/llm/pricing.py before using it. "
+            f"Known models: {', '.join(sorted(MODEL_PRICING.keys()))}"
+        )
+
+    pricing = MODEL_PRICING[model]
+    return (
+        input_tokens * pricing.input_cost_per_token
+        + output_tokens * pricing.output_cost_per_token
+    )

--- a/backend/llm/provider.py
+++ b/backend/llm/provider.py
@@ -1,0 +1,133 @@
+"""
+backend/llm/provider.py — Abstract base class for LLM providers.
+
+Every LLM provider (Anthropic, OpenAI, etc.) must implement this interface.
+The `call_llm()` function in `client.py` delegates to these implementations.
+
+This abstraction exists so that:
+- Agents never import provider SDKs directly
+- Swapping providers is a config change, not a code change
+- New providers are added by implementing one class
+
+See REQUIREMENTS.md §2.5 for the architectural rationale.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class LLMResponse:
+    """
+    Unified response from any LLM provider.
+
+    Every provider implementation must return this exact shape, regardless of
+    how the underlying SDK structures its response. This is what agents receive.
+
+    Attributes:
+        content: The text response from the LLM (or None if tool-use only)
+        tool_calls: List of tool-use results (structured data from function calling).
+                    Each item is a dict with 'name' and 'input' keys.
+        input_tokens: Number of input tokens consumed (for cost calculation)
+        output_tokens: Number of output tokens generated (for cost calculation)
+        model: The actual model that was used (may differ from requested if aliased)
+        raw_response: The full raw response object from the provider SDK,
+                      preserved for debugging and the "View system reasoning" disclosure
+    """
+    content: str | None = None
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    model: str = ""
+    raw_response: Any = None
+
+
+@dataclass
+class ToolDefinition:
+    """
+    A tool (function) that the LLM can call during generation.
+
+    Used for structured extraction — agents define their expected output schema
+    as a tool, and the LLM returns data matching that schema.
+
+    This is the provider-agnostic representation. Each provider implementation
+    converts this to its native format (Anthropic tool-use, OpenAI function calling).
+
+    Attributes:
+        name: Tool name (e.g., "extract_rfq")
+        description: What the tool does (shown to the LLM)
+        input_schema: JSON Schema defining the tool's parameters
+    """
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+class LLMProvider(ABC):
+    """
+    Abstract base class for LLM providers.
+
+    Each provider (Anthropic, OpenAI, etc.) implements this class.
+    The `call()` method is the only thing that varies per provider.
+
+    Implementations must:
+    - Convert ToolDefinition objects to the provider's native format
+    - Make the API call using the provider's SDK
+    - Convert the response to a unified LLMResponse
+    - Raise standard exceptions for errors (see client.py for handling)
+    """
+
+    @abstractmethod
+    def call(
+        self,
+        model: str,
+        system_prompt: str | None,
+        user_prompt: str,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> LLMResponse:
+        """
+        Make a single LLM API call.
+
+        Args:
+            model: Model identifier (e.g., "claude-sonnet-4-6", "gpt-4o")
+            system_prompt: System-level instructions (optional)
+            user_prompt: The user message / input to process
+            tools: Optional list of tools the LLM can call (for structured extraction)
+            max_tokens: Maximum output tokens (default 4096)
+            temperature: Sampling temperature (default 0.0 for deterministic)
+
+        Returns:
+            LLMResponse with the unified response data
+
+        Raises:
+            LLMTimeoutError: Call timed out
+            LLMRateLimitError: Provider rate limit hit
+            LLMProviderError: Any other provider-side error
+        """
+        ...
+
+
+class LLMTimeoutError(Exception):
+    """The LLM API call timed out."""
+    pass
+
+
+class LLMRateLimitError(Exception):
+    """The LLM provider's rate limit was hit."""
+    pass
+
+
+class LLMProviderError(Exception):
+    """A provider-side error occurred (not timeout or rate limit)."""
+    pass
+
+
+class LLMCostCapExceeded(Exception):
+    """
+    The daily or monthly cost cap has been reached.
+    C5 enforcement — no further LLM calls until the cap resets.
+    """
+    pass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,8 +12,9 @@ sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
 alembic>=1.14.0
 
-# Anthropic SDK — Claude API access
+# LLM provider SDKs — system is provider-agnostic (see REQUIREMENTS.md §2.5)
 anthropic>=0.42.0
+openai>=1.60.0
 
 # Environment variable loading for local dev
 python-dotenv>=1.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests/ — Test package for Golteris backend.

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,0 +1,78 @@
+"""
+tests/test_llm_pricing.py — Tests for LLM cost calculation.
+
+Verifies that calculate_cost() returns accurate USD costs for known
+token counts, and that unknown models raise KeyError (we want to fail
+loudly rather than silently logging $0.00).
+
+See NFR-OB-1: cost must match the provider's bill within 1%.
+"""
+
+import pytest
+
+from backend.llm.pricing import calculate_cost, MODEL_PRICING
+
+
+class TestCalculateCost:
+    """Tests for the calculate_cost function."""
+
+    def test_claude_sonnet_cost(self):
+        """
+        Claude Sonnet 4.6: $3/M input, $15/M output.
+        1000 input tokens = $0.003, 500 output tokens = $0.0075.
+        Total = $0.0105.
+        """
+        cost = calculate_cost("claude-sonnet-4-6", input_tokens=1000, output_tokens=500)
+        assert abs(cost - 0.0105) < 0.0001
+
+    def test_claude_opus_cost(self):
+        """
+        Claude Opus 4.6: $15/M input, $75/M output.
+        1000 input tokens = $0.015, 500 output tokens = $0.0375.
+        Total = $0.0525.
+        """
+        cost = calculate_cost("claude-opus-4-6", input_tokens=1000, output_tokens=500)
+        assert abs(cost - 0.0525) < 0.0001
+
+    def test_gpt4o_cost(self):
+        """
+        GPT-4o: $2.50/M input, $10/M output.
+        1000 input tokens = $0.0025, 500 output tokens = $0.005.
+        Total = $0.0075.
+        """
+        cost = calculate_cost("gpt-4o", input_tokens=1000, output_tokens=500)
+        assert abs(cost - 0.0075) < 0.0001
+
+    def test_gpt41_cost(self):
+        """
+        GPT-4.1: $2/M input, $8/M output.
+        1000 input tokens = $0.002, 500 output tokens = $0.004.
+        Total = $0.006.
+        """
+        cost = calculate_cost("gpt-4.1", input_tokens=1000, output_tokens=500)
+        assert abs(cost - 0.006) < 0.0001
+
+    def test_zero_tokens(self):
+        """Zero tokens should cost $0."""
+        cost = calculate_cost("claude-sonnet-4-6", input_tokens=0, output_tokens=0)
+        assert cost == 0.0
+
+    def test_unknown_model_raises(self):
+        """Unknown models must raise KeyError — never silently return $0."""
+        with pytest.raises(KeyError, match="not found in pricing table"):
+            calculate_cost("unknown-model-xyz", input_tokens=100, output_tokens=50)
+
+    def test_all_models_have_positive_pricing(self):
+        """Every model in the pricing table must have positive costs."""
+        for model_name, pricing in MODEL_PRICING.items():
+            assert pricing.input_cost_per_token > 0, f"{model_name} has zero input cost"
+            assert pricing.output_cost_per_token > 0, f"{model_name} has zero output cost"
+
+    def test_realistic_extraction_cost(self):
+        """
+        Realistic extraction call: ~850 input tokens, ~320 output tokens.
+        Claude Sonnet 4.6: ($3 * 850 + $15 * 320) / 1M = $0.00735.
+        """
+        cost = calculate_cost("claude-sonnet-4-6", input_tokens=850, output_tokens=320)
+        expected = (3.0 * 850 + 15.0 * 320) / 1_000_000
+        assert abs(cost - expected) < 0.000001


### PR DESCRIPTION
## Summary
- Provider-agnostic LLM abstraction layer (`backend/llm/`)
- Supports Anthropic Claude and OpenAI GPT with a single `call_llm()` interface
- Every call logged to `agent_calls` table: prompt, provider, model, tokens, cost, duration
- Cost cap enforcement (C5): checks daily/monthly spend before every call
- 8 pricing tests pass

Closes #21

## Test plan
- [ ] `pytest tests/test_llm_pricing.py -v` — all 8 tests pass
- [ ] `python -c "from backend.llm import call_llm; print('OK')"` — imports cleanly
- [ ] Review `client.py` — every call writes to `agent_calls`, failures recorded with status
- [ ] Review `cost_tracker.py` — caps enforce across all providers combined
- [ ] Verify `agent_calls` table exists on Render: `curl https://golteris-web.onrender.com/api/debug/tables`

🤖 Generated with [Claude Code](https://claude.com/claude-code)