### PR TITLE
#14 — Implement RFQ state transition engine

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,8 @@
+"""
+backend/services/ — Business logic and service layer for Golteris.
+
+Service modules encapsulate domain logic that is shared between API routes,
+the background worker, and agent orchestration. They operate on SQLAlchemy
+sessions and models, and are the primary place where cross-cutting constraints
+(C1-C7) are enforced in application code.
+"""

--- a/backend/services/rfq_state_machine.py
+++ b/backend/services/rfq_state_machine.py
@@ -1,0 +1,380 @@
+"""
+backend/services/rfq_state_machine.py — RFQ state transition engine.
+
+This module owns all RFQ state changes. No other code should directly update
+rfq.state — everything goes through transition_rfq() or override_rfq_state().
+
+The state machine implements the Beltmann MVP quoting flow:
+
+    needs_clarification ─→ ready_to_quote ─→ waiting_on_carriers
+                                                    │
+                                             quotes_received
+                                                    │
+                                           waiting_on_broker
+                                                    │
+                                               quote_sent
+                                              ╱    │    ╲
+                                           won   lost   cancelled
+
+    Any state ──→ cancelled  (always legal — customer abandoned, deal fell through)
+
+Design decisions:
+    - Transitions are enforced in application code, not DB constraints,
+      so that manual overrides are possible (FR-DM-4).
+    - Every state change creates an audit_events row for the RFQ detail
+      timeline (C4 — visible reasoning, FR-DM-2 — full transition history).
+    - Override bypasses the rules but still logs — the broker always has
+      a record of what happened and who did it.
+
+Called by:
+    - Agents (extraction sets initial state, validation transitions to ready_to_quote, etc.)
+    - API routes (broker approves, rejects, or manually moves an RFQ)
+    - Background worker (carrier responses trigger state changes)
+
+Cross-cutting constraints:
+    C4 — Every state change is auditable via audit_events
+    FR-DM-2 — Every RFQ has a current state AND full transition history
+    FR-DM-3 — States match the MVP lifecycle
+    FR-DM-4 — Manual override is supported and logged
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import AuditEvent, RFQ, RFQState
+
+logger = logging.getLogger("golteris.services.rfq_state_machine")
+
+
+# ---------------------------------------------------------------------------
+# Transition rules — the explicit map of what moves are legal.
+#
+# Format: {from_state: [list of allowed to_states]}
+#
+# These encode the Beltmann MVP flow. Adding a new transition is as simple
+# as adding an entry here — no other code needs to change.
+#
+# CANCELLED is always reachable from any state (deal can fall through at
+# any point). This is enforced in _is_transition_allowed() rather than
+# repeating it in every entry.
+# ---------------------------------------------------------------------------
+
+TRANSITION_RULES: dict[RFQState, list[RFQState]] = {
+    RFQState.NEEDS_CLARIFICATION: [
+        RFQState.READY_TO_QUOTE,       # Follow-up received, fields now complete
+    ],
+    RFQState.READY_TO_QUOTE: [
+        RFQState.WAITING_ON_CARRIERS,   # Carrier RFQs sent out
+        RFQState.NEEDS_CLARIFICATION,   # Re-opened — new info needed after review
+    ],
+    RFQState.WAITING_ON_CARRIERS: [
+        RFQState.QUOTES_RECEIVED,       # At least one carrier bid came back
+        RFQState.READY_TO_QUOTE,        # No bids received, need to re-quote or adjust
+    ],
+    RFQState.QUOTES_RECEIVED: [
+        RFQState.WAITING_ON_BROKER,     # Bids ranked, waiting for broker to pick one
+        RFQState.WAITING_ON_CARRIERS,   # Need more bids, sent to additional carriers
+    ],
+    RFQState.WAITING_ON_BROKER: [
+        RFQState.QUOTE_SENT,            # Broker approved and sent final quote to customer
+        RFQState.QUOTES_RECEIVED,       # Broker sent back for more carrier options
+    ],
+    RFQState.QUOTE_SENT: [
+        RFQState.WON,                   # Customer accepted the quote
+        RFQState.LOST,                  # Customer declined or went with another broker
+    ],
+    # Terminal states — no further transitions (except override)
+    RFQState.WON: [],
+    RFQState.LOST: [],
+    RFQState.CANCELLED: [],
+}
+
+
+def transition_rfq(
+    db: Session,
+    rfq_id: int,
+    new_state: RFQState,
+    actor: str,
+    reason: Optional[str] = None,
+) -> RFQ:
+    """
+    Move an RFQ to a new state through the state machine.
+
+    Validates that the transition is legal before applying it. Creates an
+    audit event recording the change for the RFQ detail timeline (C4).
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to transition.
+        new_state: The target state.
+        actor: Who is making this change — an agent name (e.g., "extraction_agent",
+               "validation_agent") or a user identifier (e.g., "jillian@beltmann.com").
+        reason: Optional human-readable reason for the transition, shown in the
+                RFQ detail timeline (e.g., "Follow-up received with missing fields",
+                "Carrier bids received from 3 carriers").
+
+    Returns:
+        The updated RFQ with the new state.
+
+    Raises:
+        ValueError: If the RFQ doesn't exist.
+        IllegalTransitionError: If the transition violates the rules.
+    """
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        raise ValueError(f"RFQ {rfq_id} not found")
+
+    old_state = rfq.state
+
+    # Validate the transition is legal
+    if not _is_transition_allowed(old_state, new_state):
+        raise IllegalTransitionError(
+            rfq_id=rfq_id,
+            from_state=old_state,
+            to_state=new_state,
+            allowed=get_allowed_transitions(old_state),
+        )
+
+    # Apply the transition
+    rfq.state = new_state
+    rfq.updated_at = datetime.utcnow()
+
+    # If moving to a terminal state, record the outcome and closed_at
+    if new_state in (RFQState.WON, RFQState.LOST, RFQState.CANCELLED):
+        rfq.outcome = new_state.value
+        rfq.closed_at = datetime.utcnow()
+
+    # Log the audit event (C4 — visible reasoning, FR-DM-2 — transition history)
+    _log_state_change(db, rfq, old_state, new_state, actor, reason)
+
+    db.commit()
+    db.refresh(rfq)
+
+    logger.info(
+        "RFQ %d transitioned: %s -> %s (actor=%s, reason=%s)",
+        rfq_id, old_state.value, new_state.value, actor, reason,
+    )
+
+    return rfq
+
+
+def override_rfq_state(
+    db: Session,
+    rfq_id: int,
+    new_state: RFQState,
+    actor: str,
+    reason: str,
+) -> RFQ:
+    """
+    Force an RFQ into any state, bypassing transition rules (FR-DM-4).
+
+    This is the manual override for when the broker needs to fix a stuck
+    RFQ, reopen a closed deal, or handle an edge case the rules don't cover.
+    The reason is REQUIRED (not optional) because overrides must be justified
+    in the audit trail.
+
+    The override is logged with event_type="state_override" so it's visually
+    distinct from normal transitions in the timeline.
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to override.
+        new_state: The target state (any state is legal for overrides).
+        actor: Who is doing this — must be a human identifier, not an agent.
+        reason: Required explanation for why the override is needed.
+
+    Returns:
+        The updated RFQ.
+
+    Raises:
+        ValueError: If the RFQ doesn't exist or reason is empty.
+    """
+    if not reason or not reason.strip():
+        raise ValueError("Override reason is required — explain why this override is needed")
+
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        raise ValueError(f"RFQ {rfq_id} not found")
+
+    old_state = rfq.state
+    rfq.state = new_state
+    rfq.updated_at = datetime.utcnow()
+
+    # Handle terminal state fields
+    if new_state in (RFQState.WON, RFQState.LOST, RFQState.CANCELLED):
+        rfq.outcome = new_state.value
+        rfq.closed_at = datetime.utcnow()
+    else:
+        # If reopening from a terminal state, clear the outcome
+        if old_state in (RFQState.WON, RFQState.LOST, RFQState.CANCELLED):
+            rfq.outcome = None
+            rfq.closed_at = None
+
+    # Log with a distinct event type so overrides stand out in the timeline
+    event = AuditEvent(
+        rfq_id=rfq.id,
+        event_type="state_override",
+        actor=actor,
+        description=f"Manual override: moved from {_state_label(old_state)} to {_state_label(new_state)} — {reason}",
+        event_data={
+            "old_state": old_state.value,
+            "new_state": new_state.value,
+            "reason": reason,
+            "override": True,
+        },
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(rfq)
+
+    logger.warning(
+        "RFQ %d OVERRIDE: %s -> %s (actor=%s, reason=%s)",
+        rfq_id, old_state.value, new_state.value, actor, reason,
+    )
+
+    return rfq
+
+
+def get_allowed_transitions(current_state: RFQState) -> list[RFQState]:
+    """
+    Return the list of states an RFQ can legally move to from its current state.
+
+    Always includes CANCELLED (unless already in a terminal state).
+    Used by the UI to show which actions are available on an RFQ.
+
+    Args:
+        current_state: The RFQ's current state.
+
+    Returns:
+        List of RFQState values that are legal transitions.
+    """
+    allowed = list(TRANSITION_RULES.get(current_state, []))
+
+    # CANCELLED is always reachable from non-terminal states
+    if current_state not in (RFQState.WON, RFQState.LOST, RFQState.CANCELLED):
+        if RFQState.CANCELLED not in allowed:
+            allowed.append(RFQState.CANCELLED)
+
+    return allowed
+
+
+def get_transition_history(db: Session, rfq_id: int) -> list[AuditEvent]:
+    """
+    Return all state change events for an RFQ, ordered chronologically.
+
+    This is how the RFQ detail timeline is populated (FR-DM-2 — full
+    transition history). Includes both normal transitions and overrides.
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to get history for.
+
+    Returns:
+        List of AuditEvent rows with event_type in ("state_changed", "state_override").
+    """
+    return (
+        db.query(AuditEvent)
+        .filter(
+            AuditEvent.rfq_id == rfq_id,
+            AuditEvent.event_type.in_(["state_changed", "state_override"]),
+        )
+        .order_by(AuditEvent.created_at.asc())
+        .all()
+    )
+
+
+def _is_transition_allowed(from_state: RFQState, to_state: RFQState) -> bool:
+    """
+    Check whether a state transition is legal per the rules.
+
+    CANCELLED is always allowed from non-terminal states (a deal can fall
+    through at any point). Other transitions must be explicitly listed in
+    TRANSITION_RULES.
+    """
+    # CANCELLED is always reachable from non-terminal states
+    if to_state == RFQState.CANCELLED:
+        return from_state not in (RFQState.WON, RFQState.LOST, RFQState.CANCELLED)
+
+    allowed = TRANSITION_RULES.get(from_state, [])
+    return to_state in allowed
+
+
+def _log_state_change(
+    db: Session,
+    rfq: RFQ,
+    old_state: RFQState,
+    new_state: RFQState,
+    actor: str,
+    reason: Optional[str],
+) -> None:
+    """
+    Create an audit event for a state transition.
+
+    Uses plain English descriptions per C3 so the broker sees something
+    meaningful in the timeline, not raw state names.
+    """
+    description = f"Moved from {_state_label(old_state)} to {_state_label(new_state)}"
+    if reason:
+        description += f" — {reason}"
+
+    event = AuditEvent(
+        rfq_id=rfq.id,
+        event_type="state_changed",
+        actor=actor,
+        description=description,
+        event_data={
+            "old_state": old_state.value,
+            "new_state": new_state.value,
+            "reason": reason,
+        },
+    )
+    db.add(event)
+
+
+def _state_label(state: RFQState) -> str:
+    """
+    Convert a state enum to a plain-English label for the UI (C3).
+
+    The broker sees "Needs clarification" not "needs_clarification".
+    """
+    labels = {
+        RFQState.NEEDS_CLARIFICATION: "Needs clarification",
+        RFQState.READY_TO_QUOTE: "Ready to quote",
+        RFQState.WAITING_ON_CARRIERS: "Waiting on carriers",
+        RFQState.QUOTES_RECEIVED: "Quotes received",
+        RFQState.WAITING_ON_BROKER: "Waiting on broker review",
+        RFQState.QUOTE_SENT: "Quote sent",
+        RFQState.WON: "Won",
+        RFQState.LOST: "Lost",
+        RFQState.CANCELLED: "Cancelled",
+    }
+    return labels.get(state, state.value)
+
+
+class IllegalTransitionError(Exception):
+    """
+    Raised when code attempts a state transition that violates the rules.
+
+    Includes the from/to states and the allowed transitions so the caller
+    (or the broker in the UI) can understand what went wrong.
+    """
+
+    def __init__(
+        self,
+        rfq_id: int,
+        from_state: RFQState,
+        to_state: RFQState,
+        allowed: list[RFQState],
+    ):
+        self.rfq_id = rfq_id
+        self.from_state = from_state
+        self.to_state = to_state
+        self.allowed = allowed
+        allowed_names = [s.value for s in allowed]
+        super().__init__(
+            f"Cannot transition RFQ {rfq_id} from {from_state.value} to {to_state.value}. "
+            f"Allowed transitions: {allowed_names}"
+        )

--- a/tests/test_rfq_state_machine.py
+++ b/tests/test_rfq_state_machine.py
@@ -1,0 +1,284 @@
+"""
+tests/test_rfq_state_machine.py — Tests for the RFQ state transition engine (#14).
+
+Verifies the four acceptance criteria:
+    1. RFQs have a current state and transition history (FR-DM-2)
+    2. State changes happen through explicit rules, not ad hoc updates (FR-DM-3)
+    3. Human override is possible and logged (FR-DM-4)
+    4. Initial states support the Beltmann MVP quoting flow
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.db.models import AuditEvent, Base, RFQ, RFQState
+from backend.services.rfq_state_machine import (
+    TRANSITION_RULES,
+    IllegalTransitionError,
+    get_allowed_transitions,
+    get_transition_history,
+    override_rfq_state,
+    transition_rfq,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_compatible():
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _create_rfq(db, state=RFQState.NEEDS_CLARIFICATION) -> RFQ:
+    """Create a minimal RFQ in the given state."""
+    rfq = RFQ(
+        customer_name="Test Customer",
+        origin="Dallas, TX",
+        destination="Atlanta, GA",
+        state=state,
+    )
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+# ---------------------------------------------------------------------------
+# Transition rule tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionRules:
+    """Acceptance criterion: state changes happen through explicit rules."""
+
+    def test_happy_path_full_lifecycle(self, db):
+        """Walk the full Beltmann MVP flow from start to won."""
+        rfq = _create_rfq(db, RFQState.NEEDS_CLARIFICATION)
+
+        transition_rfq(db, rfq.id, RFQState.READY_TO_QUOTE, "validation_agent", "Follow-up received")
+        assert rfq.state == RFQState.READY_TO_QUOTE
+
+        transition_rfq(db, rfq.id, RFQState.WAITING_ON_CARRIERS, "distribution_agent", "Sent to 5 carriers")
+        assert rfq.state == RFQState.WAITING_ON_CARRIERS
+
+        transition_rfq(db, rfq.id, RFQState.QUOTES_RECEIVED, "bid_parser", "3 bids received")
+        assert rfq.state == RFQState.QUOTES_RECEIVED
+
+        transition_rfq(db, rfq.id, RFQState.WAITING_ON_BROKER, "comparison_agent", "Bids ranked")
+        assert rfq.state == RFQState.WAITING_ON_BROKER
+
+        transition_rfq(db, rfq.id, RFQState.QUOTE_SENT, "jillian@beltmann.com", "Approved final quote")
+        assert rfq.state == RFQState.QUOTE_SENT
+
+        transition_rfq(db, rfq.id, RFQState.WON, "jillian@beltmann.com", "Customer accepted")
+        assert rfq.state == RFQState.WON
+        assert rfq.outcome == "won"
+        assert rfq.closed_at is not None
+
+    def test_illegal_transition_raises(self, db):
+        """Jumping from needs_clarification to quote_sent should fail."""
+        rfq = _create_rfq(db, RFQState.NEEDS_CLARIFICATION)
+
+        with pytest.raises(IllegalTransitionError) as exc_info:
+            transition_rfq(db, rfq.id, RFQState.QUOTE_SENT, "rogue_agent")
+
+        assert exc_info.value.from_state == RFQState.NEEDS_CLARIFICATION
+        assert exc_info.value.to_state == RFQState.QUOTE_SENT
+
+    def test_cancelled_always_reachable(self, db):
+        """CANCELLED should be reachable from any non-terminal state."""
+        for state in [
+            RFQState.NEEDS_CLARIFICATION,
+            RFQState.READY_TO_QUOTE,
+            RFQState.WAITING_ON_CARRIERS,
+            RFQState.QUOTES_RECEIVED,
+            RFQState.WAITING_ON_BROKER,
+            RFQState.QUOTE_SENT,
+        ]:
+            rfq = _create_rfq(db, state)
+            transition_rfq(db, rfq.id, RFQState.CANCELLED, "jillian@beltmann.com", "Deal fell through")
+            assert rfq.state == RFQState.CANCELLED
+
+    def test_cannot_transition_from_terminal(self, db):
+        """Won, Lost, and Cancelled are terminal — no further transitions."""
+        for terminal_state in [RFQState.WON, RFQState.LOST, RFQState.CANCELLED]:
+            rfq = _create_rfq(db, terminal_state)
+            with pytest.raises(IllegalTransitionError):
+                transition_rfq(db, rfq.id, RFQState.READY_TO_QUOTE, "test")
+
+    def test_cannot_cancel_terminal_state(self, db):
+        """Can't cancel something that's already won/lost/cancelled."""
+        rfq = _create_rfq(db, RFQState.WON)
+        with pytest.raises(IllegalTransitionError):
+            transition_rfq(db, rfq.id, RFQState.CANCELLED, "test")
+
+    def test_backward_transition_allowed_where_defined(self, db):
+        """ready_to_quote -> needs_clarification is legal (re-opened)."""
+        rfq = _create_rfq(db, RFQState.READY_TO_QUOTE)
+        transition_rfq(db, rfq.id, RFQState.NEEDS_CLARIFICATION, "validation_agent", "New info needed")
+        assert rfq.state == RFQState.NEEDS_CLARIFICATION
+
+    def test_nonexistent_rfq_raises(self, db):
+        with pytest.raises(ValueError, match="not found"):
+            transition_rfq(db, 99999, RFQState.READY_TO_QUOTE, "test")
+
+    def test_terminal_state_sets_outcome_and_closed_at(self, db):
+        """Moving to won/lost/cancelled should populate outcome and closed_at."""
+        rfq = _create_rfq(db, RFQState.QUOTE_SENT)
+
+        transition_rfq(db, rfq.id, RFQState.LOST, "jillian@beltmann.com", "Customer went elsewhere")
+        assert rfq.outcome == "lost"
+        assert rfq.closed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Audit logging tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogging:
+    """Acceptance criterion: RFQs have transition history (FR-DM-2)."""
+
+    def test_transition_creates_audit_event(self, db):
+        """Every transition should create an audit event."""
+        rfq = _create_rfq(db)
+        transition_rfq(db, rfq.id, RFQState.READY_TO_QUOTE, "validation_agent", "Fields complete")
+
+        events = db.query(AuditEvent).filter(AuditEvent.rfq_id == rfq.id).all()
+        assert len(events) == 1
+        assert events[0].event_type == "state_changed"
+        assert events[0].actor == "validation_agent"
+        assert "Ready to quote" in events[0].description
+        assert events[0].event_data["old_state"] == "needs_clarification"
+        assert events[0].event_data["new_state"] == "ready_to_quote"
+
+    def test_transition_history_ordered(self, db):
+        """get_transition_history should return events in chronological order."""
+        rfq = _create_rfq(db)
+        transition_rfq(db, rfq.id, RFQState.READY_TO_QUOTE, "agent", "Step 1")
+        transition_rfq(db, rfq.id, RFQState.WAITING_ON_CARRIERS, "agent", "Step 2")
+        transition_rfq(db, rfq.id, RFQState.QUOTES_RECEIVED, "agent", "Step 3")
+
+        history = get_transition_history(db, rfq.id)
+        assert len(history) == 3
+        assert history[0].event_data["new_state"] == "ready_to_quote"
+        assert history[1].event_data["new_state"] == "waiting_on_carriers"
+        assert history[2].event_data["new_state"] == "quotes_received"
+
+    def test_reason_appears_in_description(self, db):
+        """The reason should be included in the plain-English description."""
+        rfq = _create_rfq(db)
+        transition_rfq(db, rfq.id, RFQState.READY_TO_QUOTE, "agent", "Customer provided missing weight")
+
+        events = get_transition_history(db, rfq.id)
+        assert "Customer provided missing weight" in events[0].description
+
+
+# ---------------------------------------------------------------------------
+# Override tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverride:
+    """Acceptance criterion: human override is possible and logged (FR-DM-4)."""
+
+    def test_override_bypasses_rules(self, db):
+        """Override should allow any transition, even illegal ones."""
+        rfq = _create_rfq(db, RFQState.NEEDS_CLARIFICATION)
+
+        # This would fail with transition_rfq — needs_clarification -> quote_sent is illegal
+        result = override_rfq_state(
+            db, rfq.id, RFQState.QUOTE_SENT,
+            "jillian@beltmann.com", "Customer already got pricing verbally, just logging it"
+        )
+        assert result.state == RFQState.QUOTE_SENT
+
+    def test_override_logs_distinct_event_type(self, db):
+        """Override events should have event_type='state_override' to stand out."""
+        rfq = _create_rfq(db)
+        override_rfq_state(db, rfq.id, RFQState.WON, "jillian@beltmann.com", "Verbal confirmation")
+
+        events = db.query(AuditEvent).filter(AuditEvent.rfq_id == rfq.id).all()
+        assert len(events) == 1
+        assert events[0].event_type == "state_override"
+        assert events[0].event_data["override"] is True
+        assert "Manual override" in events[0].description
+
+    def test_override_requires_reason(self, db):
+        """Override without a reason should raise ValueError."""
+        rfq = _create_rfq(db)
+        with pytest.raises(ValueError, match="reason is required"):
+            override_rfq_state(db, rfq.id, RFQState.WON, "jillian@beltmann.com", "")
+
+    def test_override_can_reopen_terminal(self, db):
+        """Override can move a won/lost/cancelled RFQ back to an active state."""
+        rfq = _create_rfq(db, RFQState.LOST)
+        override_rfq_state(
+            db, rfq.id, RFQState.WAITING_ON_BROKER,
+            "jillian@beltmann.com", "Customer came back, reconsidering"
+        )
+        assert rfq.state == RFQState.WAITING_ON_BROKER
+        assert rfq.outcome is None  # Cleared when reopened
+        assert rfq.closed_at is None
+
+    def test_override_nonexistent_rfq_raises(self, db):
+        with pytest.raises(ValueError, match="not found"):
+            override_rfq_state(db, 99999, RFQState.WON, "test", "reason")
+
+
+# ---------------------------------------------------------------------------
+# Allowed transitions helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllowedTransitions:
+    """get_allowed_transitions should return correct options for the UI."""
+
+    def test_needs_clarification_options(self):
+        allowed = get_allowed_transitions(RFQState.NEEDS_CLARIFICATION)
+        assert RFQState.READY_TO_QUOTE in allowed
+        assert RFQState.CANCELLED in allowed
+        assert RFQState.WON not in allowed
+
+    def test_terminal_states_have_no_transitions(self):
+        for terminal in [RFQState.WON, RFQState.LOST, RFQState.CANCELLED]:
+            assert get_allowed_transitions(terminal) == []
+
+    def test_quote_sent_options(self):
+        allowed = get_allowed_transitions(RFQState.QUOTE_SENT)
+        assert RFQState.WON in allowed
+        assert RFQState.LOST in allowed
+        assert RFQState.CANCELLED in allowed
+
+
+# ---------------------------------------------------------------------------
+# Every state covered
+# ---------------------------------------------------------------------------
+
+
+class TestAllStatesHaveRules:
+    """Every RFQState enum value should have an entry in TRANSITION_RULES."""
+
+    def test_all_states_in_rules(self):
+        for state in RFQState:
+            assert state in TRANSITION_RULES, f"{state.value} missing from TRANSITION_RULES"


### PR DESCRIPTION
## Summary
- Explicit state machine for the Beltmann MVP quoting flow with `TRANSITION_RULES` dict
- `transition_rfq()` validates + logs, `override_rfq_state()` bypasses rules with required reason
- CANCELLED reachable from any non-terminal state, terminal states set outcome/closed_at
- Plain-English state labels for C3, audit events for C4, full transition history for FR-DM-2
- 20 tests covering full lifecycle, illegal transitions, backward transitions, overrides, audit logging

Closes #14

## Test plan
- [ ] `python -m pytest tests/test_rfq_state_machine.py -v` — 20/20 pass
- [ ] `python -m pytest tests/ -v` — no regressions
- [ ] Review TRANSITION_RULES matches Beltmann MVP flow
- [ ] Verify override requires reason and logs distinctly
- [ ] Verify terminal states populate outcome + closed_at

🤖 Generated with [Claude Code](https://claude.com/claude-code)