### PR TITLE
#15 — Build missing-information detection and follow-up drafting

### DIFF
--- a/backend/agents/validation.py
+++ b/backend/agents/validation.py
@@ -1,0 +1,375 @@
+"""
+backend/agents/validation.py — Missing-information detection and follow-up drafting.
+
+This is the second agent in the pipeline, triggered after extraction when an
+RFQ lands in needs_clarification state. It does two things:
+
+    1. Identifies exactly which required fields are missing or low-confidence
+    2. Calls the LLM to draft a professional follow-up email asking for those fields
+
+The drafted follow-up is stored as an approval record (status=pending_approval)
+so the broker can review, edit, or reject it before it's sent. This is the C2
+enforcement point — nothing goes outbound without human approval.
+
+Pipeline position:
+    Extraction (#24) creates RFQ in needs_clarification
+    -> This agent detects what's missing and drafts the follow-up
+    -> Broker reviews in the HITL approval flow (#26)
+    -> If approved, outbound email sends (#25)
+    -> Customer replies with missing info (#07 in seed data)
+    -> Matching service (#13) attaches reply to the RFQ
+    -> State transitions to ready_to_quote (#14)
+
+Called by:
+    - The background worker after extraction creates a needs_clarification RFQ
+    - Manually for testing: `validate_and_draft(db, rfq_id)`
+
+Cross-cutting constraints:
+    C2 — Draft persists as pending_approval; NEVER auto-sends
+    C3 — Follow-up email uses professional broker language, not agent jargon
+    C4 — LLM call logged via agent_calls, run tracked via agent_runs
+    C5 — Cost caps enforced at call_llm level
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import (
+    Approval,
+    ApprovalStatus,
+    ApprovalType,
+    AuditEvent,
+    RFQ,
+    RFQState,
+)
+from backend.llm.client import call_llm
+from backend.llm.provider import ToolDefinition
+from backend.services.agent_runs import fail_run, finish_run, start_run
+
+logger = logging.getLogger("golteris.agents.validation")
+
+
+# ---------------------------------------------------------------------------
+# Required fields — these must be present and high-confidence for an RFQ
+# to be quotable. If any are missing or low-confidence, a follow-up is needed.
+#
+# This matches FR-AG-4 and the extraction agent's confidence threshold.
+# ---------------------------------------------------------------------------
+
+REQUIRED_FIELDS = {
+    "origin": "pickup location (city and state)",
+    "destination": "delivery location (city and state)",
+    "equipment_type": "truck/trailer type (flatbed, van, reefer, etc.)",
+    "truck_count": "number of trucks needed",
+    "commodity": "what is being shipped",
+}
+
+# Weight is important for quoting but not strictly required — many initial
+# RFQs don't include it and the broker can estimate. We flag it but don't
+# block on it.
+RECOMMENDED_FIELDS = {
+    "weight_lbs": "approximate weight per truck in pounds",
+    "pickup_date": "requested pickup date",
+    "delivery_date": "requested delivery date",
+}
+
+CONFIDENCE_THRESHOLD = 0.90
+
+
+# ---------------------------------------------------------------------------
+# Tool-use schema for follow-up email drafting
+# ---------------------------------------------------------------------------
+
+DRAFT_FOLLOWUP_TOOL = ToolDefinition(
+    name="draft_followup_email",
+    description=(
+        "Draft a professional follow-up email to the customer asking for the "
+        "specific missing information needed to complete their freight quote request. "
+        "The email should be friendly, concise, and clearly list what's needed."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "subject": {
+                "type": "string",
+                "description": "Email subject line (e.g., 'Re: Quote Request — A few details needed')",
+            },
+            "body": {
+                "type": "string",
+                "description": "Full email body. Professional tone, references the customer by name if known, lists exactly what's missing, and offers to help.",
+            },
+        },
+        "required": ["subject", "body"],
+    },
+)
+
+
+FOLLOWUP_SYSTEM_PROMPT = """You are a freight broker assistant drafting a follow-up email to a customer whose quote request is missing information.
+
+Rules:
+- Be professional, friendly, and concise — this is a business email from a logistics broker.
+- Address the customer by name if known.
+- Reference their original request so they know what this is about.
+- Clearly list ONLY the specific missing items — don't ask for information they already provided.
+- If a field was ambiguous (not missing, but unclear), ask for clarification rather than saying it's "missing."
+- Keep the tone helpful, not demanding — "Could you let us know..." not "You failed to provide..."
+- Sign off as the Beltmann team.
+- Do NOT include any internal system language, confidence scores, field names, or technical jargon.
+
+Use the draft_followup_email tool to return your draft."""
+
+
+def detect_missing_info(db: Session, rfq_id: int) -> dict:
+    """
+    Analyze an RFQ and identify which required fields are missing or low-confidence.
+
+    Returns a dict with:
+        - missing_required: list of (field_name, human_label) for null required fields
+        - low_confidence: list of (field_name, human_label, score) for below-threshold fields
+        - missing_recommended: list of (field_name, human_label) for null recommended fields
+        - needs_followup: bool — True if any required fields are missing or low-confidence
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to analyze.
+
+    Returns:
+        Analysis dict, or None if the RFQ doesn't exist.
+    """
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        return None
+
+    confidence = rfq.confidence_scores or {}
+
+    missing_required = []
+    low_confidence = []
+    missing_recommended = []
+
+    # Check required fields — these block quoting
+    for field_name, human_label in REQUIRED_FIELDS.items():
+        value = getattr(rfq, field_name, None)
+        if value is None:
+            missing_required.append((field_name, human_label))
+        else:
+            score = confidence.get(field_name, 1.0)
+            if score < CONFIDENCE_THRESHOLD:
+                low_confidence.append((field_name, human_label, score))
+
+    # Check recommended fields — nice to have but don't block
+    for field_name, human_label in RECOMMENDED_FIELDS.items():
+        value = getattr(rfq, field_name, None)
+        if value is None:
+            missing_recommended.append((field_name, human_label))
+
+    return {
+        "missing_required": missing_required,
+        "low_confidence": low_confidence,
+        "missing_recommended": missing_recommended,
+        "needs_followup": len(missing_required) > 0 or len(low_confidence) > 0,
+    }
+
+
+def draft_followup(
+    db: Session,
+    rfq_id: int,
+) -> Optional[Approval]:
+    """
+    Draft a follow-up email for an RFQ that needs clarification.
+
+    Detects missing/low-confidence fields, then calls the LLM to generate
+    a professional follow-up email. The draft is stored as an approval record
+    with status=pending_approval so the broker reviews it before sending (C2).
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to draft a follow-up for.
+
+    Returns:
+        The Approval record containing the draft, or None if no follow-up
+        is needed (all required fields are present and high-confidence).
+
+    Side effects:
+        - Creates an agent_run (via run tracking service)
+        - Creates agent_calls (via call_llm)
+        - Creates an approvals row with status=pending_approval (C2)
+        - Creates an audit_events row for the RFQ timeline
+    """
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        logger.error("RFQ %d not found — cannot draft follow-up", rfq_id)
+        return None
+
+    # Detect what's missing
+    analysis = detect_missing_info(db, rfq_id)
+    if not analysis["needs_followup"]:
+        logger.info("RFQ %d has all required fields — no follow-up needed", rfq_id)
+        return None
+
+    # Start an agent run
+    run = start_run(
+        db,
+        workflow_name="Missing Info Follow-up",
+        rfq_id=rfq_id,
+        trigger_source="validation",
+    )
+
+    try:
+        # Build the prompt describing what's missing
+        user_prompt = _build_followup_prompt(rfq, analysis)
+
+        # Call the LLM to draft the email
+        response = call_llm(
+            db=db,
+            run_id=run.id,
+            agent_name="validation",
+            system_prompt=FOLLOWUP_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            tools=[DRAFT_FOLLOWUP_TOOL],
+            temperature=0.3,  # Slightly creative for natural email tone
+        )
+
+        # Parse the tool response
+        draft = _parse_draft_response(response)
+        if not draft:
+            logger.warning("LLM did not call draft_followup_email tool for RFQ %d", rfq_id)
+            fail_run(db, run.id, "LLM did not return tool-use result")
+            return None
+
+        # Create the approval record — C2 enforcement point.
+        # The draft sits here with status=pending_approval until the broker
+        # reviews it in the HITL flow (#26).
+        approval = Approval(
+            rfq_id=rfq_id,
+            approval_type=ApprovalType.CUSTOMER_REPLY,
+            draft_subject=draft["subject"],
+            draft_body=draft["body"],
+            draft_recipient=rfq.customer_email,
+            reason=_build_reason_text(analysis),
+            status=ApprovalStatus.PENDING_APPROVAL,
+        )
+        db.add(approval)
+
+        # Log audit event — plain English per C3
+        _log_audit_event(db, rfq, analysis)
+
+        db.commit()
+        db.refresh(approval)
+
+        finish_run(db, run.id)
+
+        logger.info(
+            "Follow-up drafted for RFQ %d: %d missing required, %d low confidence",
+            rfq_id, len(analysis["missing_required"]), len(analysis["low_confidence"]),
+        )
+
+        return approval
+
+    except Exception as e:
+        logger.exception("Follow-up drafting failed for RFQ %d: %s", rfq_id, e)
+        fail_run(db, run.id, str(e))
+        raise
+
+
+def _build_followup_prompt(rfq: RFQ, analysis: dict) -> str:
+    """
+    Build the user prompt describing the RFQ and what's missing.
+
+    Gives the LLM enough context about the original request to draft
+    a relevant, personalized follow-up — not a generic template.
+    """
+    lines = []
+    lines.append(f"Customer: {rfq.customer_name or 'Unknown'} ({rfq.customer_email or 'no email'})")
+    lines.append(f"Company: {rfq.customer_company or 'Unknown'}")
+    lines.append("")
+    lines.append("What we know so far from their request:")
+    if rfq.origin:
+        lines.append(f"  - Origin: {rfq.origin}")
+    if rfq.destination:
+        lines.append(f"  - Destination: {rfq.destination}")
+    if rfq.equipment_type:
+        lines.append(f"  - Equipment: {rfq.equipment_type}")
+    if rfq.truck_count:
+        lines.append(f"  - Trucks: {rfq.truck_count}")
+    if rfq.commodity:
+        lines.append(f"  - Commodity: {rfq.commodity}")
+    if rfq.weight_lbs:
+        lines.append(f"  - Weight: {rfq.weight_lbs} lbs")
+
+    lines.append("")
+    lines.append("MISSING INFORMATION (must ask for):")
+    for field_name, human_label in analysis["missing_required"]:
+        lines.append(f"  - {human_label}")
+
+    if analysis["low_confidence"]:
+        lines.append("")
+        lines.append("UNCLEAR / NEEDS CLARIFICATION:")
+        for field_name, human_label, score in analysis["low_confidence"]:
+            value = getattr(rfq, field_name, None)
+            lines.append(f"  - {human_label}: they said \"{value}\" but this is ambiguous")
+
+    if analysis["missing_recommended"]:
+        lines.append("")
+        lines.append("OPTIONAL (nice to have, ask if natural):")
+        for field_name, human_label in analysis["missing_recommended"]:
+            lines.append(f"  - {human_label}")
+
+    return "\n".join(lines)
+
+
+def _parse_draft_response(response) -> Optional[dict]:
+    """Extract the draft email from the LLM's tool-use response."""
+    if not response.tool_calls:
+        return None
+
+    for tool_call in response.tool_calls:
+        if tool_call.get("name") == "draft_followup_email":
+            return tool_call.get("input", {})
+
+    return None
+
+
+def _build_reason_text(analysis: dict) -> str:
+    """
+    Build a human-readable reason for why this follow-up was flagged.
+
+    Shown in the approval modal as the "reason" badge so the broker
+    understands why this draft was created. Uses plain English per C3.
+    """
+    parts = []
+    if analysis["missing_required"]:
+        fields = [label for _, label in analysis["missing_required"]]
+        parts.append(f"Missing: {', '.join(fields)}")
+    if analysis["low_confidence"]:
+        fields = [label for _, label, _ in analysis["low_confidence"]]
+        parts.append(f"Unclear: {', '.join(fields)}")
+    return "; ".join(parts) or "Review needed"
+
+
+def _log_audit_event(db: Session, rfq: RFQ, analysis: dict) -> None:
+    """
+    Create an audit event for the RFQ timeline.
+
+    Uses plain English per C3 — the broker sees "Draft follow-up prepared"
+    not "validation_agent_completed" or "missing_info_detected."
+    """
+    missing_labels = [label for _, label in analysis["missing_required"]]
+    unclear_labels = [label for _, label, _ in analysis["low_confidence"]]
+    all_items = missing_labels + unclear_labels
+
+    description = f"Draft follow-up prepared — asking for: {', '.join(all_items)}"
+
+    event = AuditEvent(
+        rfq_id=rfq.id,
+        event_type="followup_drafted",
+        actor="validation_agent",
+        description=description,
+        event_data={
+            "missing_required": [f for f, _ in analysis["missing_required"]],
+            "low_confidence": [f for f, _, _ in analysis["low_confidence"]],
+            "missing_recommended": [f for f, _ in analysis["missing_recommended"]],
+        },
+    )
+    db.add(event)

--- a/tests/test_validation_agent.py
+++ b/tests/test_validation_agent.py
@@ -1,0 +1,369 @@
+"""
+tests/test_validation_agent.py — Tests for missing-info detection and follow-up drafting (#15).
+
+Verifies the three acceptance criteria:
+    1. The system can flag missing required fields from a sample Beltmann-style email
+    2. A draft follow-up email is generated with the missing items called out clearly
+    3. The draft is reviewable before sending (persisted as pending_approval)
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.agents.validation import (
+    CONFIDENCE_THRESHOLD,
+    REQUIRED_FIELDS,
+    detect_missing_info,
+    draft_followup,
+)
+from backend.db.models import (
+    Approval,
+    ApprovalStatus,
+    ApprovalType,
+    AuditEvent,
+    Base,
+    RFQ,
+    RFQState,
+)
+from backend.llm.provider import LLMResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_compatible():
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _create_rfq(db, **kwargs) -> RFQ:
+    """Create an RFQ with given fields. Unspecified fields default to None."""
+    defaults = {
+        "customer_name": "Test Customer",
+        "customer_email": "test@example.com",
+        "state": RFQState.NEEDS_CLARIFICATION,
+    }
+    defaults.update(kwargs)
+    rfq = RFQ(**defaults)
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+# ---------------------------------------------------------------------------
+# detect_missing_info tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMissingInfo:
+    """Acceptance criterion: flag missing required fields."""
+
+    def test_complete_rfq_has_no_missing(self, db):
+        """An RFQ with all required fields should not need follow-up."""
+        rfq = _create_rfq(
+            db,
+            origin="Dallas, TX",
+            destination="Atlanta, GA",
+            equipment_type="Flatbed",
+            truck_count=1,
+            commodity="Steel coils",
+            weight_lbs=42000,
+            confidence_scores={
+                "origin": 0.98, "destination": 0.98, "equipment_type": 0.99,
+                "truck_count": 0.99, "commodity": 0.97, "weight_lbs": 0.98,
+            },
+        )
+        result = detect_missing_info(db, rfq.id)
+
+        assert result["needs_followup"] is False
+        assert len(result["missing_required"]) == 0
+        assert len(result["low_confidence"]) == 0
+
+    def test_missing_commodity_and_weight(self, db):
+        """Seed email 03 pattern: missing commodity and weight."""
+        rfq = _create_rfq(
+            db,
+            origin="Chicago, IL",
+            destination="Detroit, MI",
+            equipment_type="Van",
+            truck_count=1,
+            commodity=None,
+            weight_lbs=None,
+            confidence_scores={
+                "origin": 0.95, "destination": 0.95, "equipment_type": 0.92,
+                "truck_count": 0.99, "commodity": 0.0, "weight_lbs": 0.0,
+            },
+        )
+        result = detect_missing_info(db, rfq.id)
+
+        assert result["needs_followup"] is True
+        missing_fields = [f for f, _ in result["missing_required"]]
+        assert "commodity" in missing_fields
+        # weight_lbs is recommended, not required
+        recommended_fields = [f for f, _ in result["missing_recommended"]]
+        assert "weight_lbs" in recommended_fields
+
+    def test_low_confidence_destination(self, db):
+        """Seed email 05 pattern: ambiguous 'Springfield' with low confidence."""
+        rfq = _create_rfq(
+            db,
+            origin="Kansas City, MO",
+            destination="Springfield",
+            equipment_type="Van",
+            truck_count=1,
+            commodity="Household goods",
+            weight_lbs=35000,
+            confidence_scores={
+                "origin": 0.93, "destination": 0.45,
+                "equipment_type": 0.97, "truck_count": 0.99,
+                "commodity": 0.95, "weight_lbs": 0.94,
+            },
+        )
+        result = detect_missing_info(db, rfq.id)
+
+        assert result["needs_followup"] is True
+        assert len(result["missing_required"]) == 0  # Nothing null
+        low_conf_fields = [f for f, _, _ in result["low_confidence"]]
+        assert "destination" in low_conf_fields
+
+    def test_missing_dates_are_recommended(self, db):
+        """Seed email 04 pattern: missing dates flagged as recommended, not required."""
+        rfq = _create_rfq(
+            db,
+            origin="Indianapolis, IN",
+            destination="Columbus, OH",
+            equipment_type="Reefer",
+            truck_count=1,
+            commodity="Pharmaceuticals",
+            weight_lbs=38000,
+            pickup_date=None,
+            delivery_date=None,
+            confidence_scores={
+                "origin": 0.98, "destination": 0.98, "equipment_type": 0.97,
+                "truck_count": 0.99, "commodity": 0.95, "weight_lbs": 0.96,
+            },
+        )
+        result = detect_missing_info(db, rfq.id)
+
+        # Dates are recommended, not required — shouldn't trigger needs_followup
+        # unless a required field is also missing
+        assert result["needs_followup"] is False
+        recommended_fields = [f for f, _ in result["missing_recommended"]]
+        assert "pickup_date" in recommended_fields
+        assert "delivery_date" in recommended_fields
+
+    def test_nonexistent_rfq_returns_none(self, db):
+        result = detect_missing_info(db, 99999)
+        assert result is None
+
+    def test_no_confidence_scores_defaults_high(self, db):
+        """RFQ with no confidence_scores should default to 1.0 (assume confident)."""
+        rfq = _create_rfq(
+            db,
+            origin="A", destination="B", equipment_type="Van",
+            truck_count=1, commodity="Stuff",
+            confidence_scores=None,
+        )
+        result = detect_missing_info(db, rfq.id)
+        assert result["needs_followup"] is False
+
+
+# ---------------------------------------------------------------------------
+# draft_followup tests (mocked LLM)
+# ---------------------------------------------------------------------------
+
+
+class TestDraftFollowup:
+    """Acceptance criteria: draft follow-up generated and reviewable."""
+
+    @patch("backend.agents.validation.call_llm")
+    @patch("backend.agents.validation.start_run")
+    @patch("backend.agents.validation.finish_run")
+    def test_drafts_followup_for_missing_fields(self, mock_finish, mock_start, mock_llm, db):
+        """Missing commodity -> draft follow-up with pending_approval status (C2)."""
+        rfq = _create_rfq(
+            db,
+            origin="Chicago, IL",
+            destination="Detroit, MI",
+            equipment_type="Van",
+            truck_count=1,
+            commodity=None,
+            confidence_scores={"origin": 0.95, "destination": 0.95,
+                               "equipment_type": 0.92, "truck_count": 0.99,
+                               "commodity": 0.0, "weight_lbs": 0.0},
+        )
+
+        mock_run = MagicMock()
+        mock_run.id = 1
+        mock_start.return_value = mock_run
+
+        mock_llm.return_value = LLMResponse(
+            content=None,
+            tool_calls=[{
+                "name": "draft_followup_email",
+                "input": {
+                    "subject": "Re: Need a truck ASAP — A couple details needed",
+                    "body": "Hi Mike,\n\nThanks for reaching out about the Chicago to Detroit move. We'd love to get you a rate — could you let us know:\n\n- What commodity will be shipped?\n- Approximate weight per truck?\n\nOnce we have those details, we'll get you a quote right away.\n\nBest,\nBeltmann Logistics",
+                },
+            }],
+            input_tokens=800,
+            output_tokens=200,
+            model="claude-sonnet-4-6",
+        )
+
+        approval = draft_followup(db, rfq.id)
+
+        # C2: draft stored as pending_approval
+        assert approval is not None
+        assert approval.status == ApprovalStatus.PENDING_APPROVAL
+        assert approval.approval_type == ApprovalType.CUSTOMER_REPLY
+        assert "couple details needed" in approval.draft_subject
+        assert "commodity" in approval.draft_body.lower() or "shipped" in approval.draft_body.lower()
+        assert approval.draft_recipient == "test@example.com"
+        assert "commodity" in approval.reason.lower() or "missing" in approval.reason.lower()
+
+    @patch("backend.agents.validation.call_llm")
+    @patch("backend.agents.validation.start_run")
+    @patch("backend.agents.validation.finish_run")
+    def test_no_followup_for_complete_rfq(self, mock_finish, mock_start, mock_llm, db):
+        """Complete RFQ should return None — no follow-up needed."""
+        rfq = _create_rfq(
+            db,
+            origin="Dallas, TX", destination="Atlanta, GA",
+            equipment_type="Flatbed", truck_count=1, commodity="Steel",
+            confidence_scores={"origin": 0.98, "destination": 0.98,
+                               "equipment_type": 0.99, "truck_count": 0.99,
+                               "commodity": 0.97, "weight_lbs": 0.98},
+        )
+
+        result = draft_followup(db, rfq.id)
+
+        assert result is None
+        mock_llm.assert_not_called()  # No LLM call needed
+
+    @patch("backend.agents.validation.call_llm")
+    @patch("backend.agents.validation.start_run")
+    @patch("backend.agents.validation.finish_run")
+    def test_low_confidence_triggers_followup(self, mock_finish, mock_start, mock_llm, db):
+        """Ambiguous destination (confidence 0.45) should trigger a follow-up."""
+        rfq = _create_rfq(
+            db,
+            origin="Kansas City, MO", destination="Springfield",
+            equipment_type="Van", truck_count=1, commodity="Household goods",
+            weight_lbs=35000,
+            confidence_scores={"origin": 0.93, "destination": 0.45,
+                               "equipment_type": 0.97, "truck_count": 0.99,
+                               "commodity": 0.95, "weight_lbs": 0.94},
+        )
+
+        mock_run = MagicMock()
+        mock_run.id = 2
+        mock_start.return_value = mock_run
+
+        mock_llm.return_value = LLMResponse(
+            content=None,
+            tool_calls=[{
+                "name": "draft_followup_email",
+                "input": {
+                    "subject": "Re: Quote - Van Load to Springfield — Quick clarification",
+                    "body": "Hi David,\n\nThanks for the quote request for the Kansas City to Springfield van load. Just a quick question — could you confirm which Springfield you need delivery to? (Springfield, MO or Springfield, IL?)\n\nWe'll get your rate over as soon as we confirm.\n\nBest,\nBeltmann Logistics",
+                },
+            }],
+            input_tokens=700,
+            output_tokens=180,
+            model="claude-sonnet-4-6",
+        )
+
+        approval = draft_followup(db, rfq.id)
+
+        assert approval is not None
+        assert approval.status == ApprovalStatus.PENDING_APPROVAL
+        assert "Springfield" in approval.draft_body or "destination" in approval.reason.lower()
+
+    @patch("backend.agents.validation.call_llm")
+    @patch("backend.agents.validation.start_run")
+    @patch("backend.agents.validation.finish_run")
+    def test_audit_event_created(self, mock_finish, mock_start, mock_llm, db):
+        """Drafting a follow-up should create a plain-English audit event (C3)."""
+        rfq = _create_rfq(
+            db,
+            origin="A", destination="B", equipment_type="Van",
+            truck_count=1, commodity=None,
+            confidence_scores={"origin": 0.98, "destination": 0.98,
+                               "equipment_type": 0.99, "truck_count": 0.99,
+                               "commodity": 0.0, "weight_lbs": 0.0},
+        )
+
+        mock_run = MagicMock()
+        mock_run.id = 3
+        mock_start.return_value = mock_run
+        mock_llm.return_value = LLMResponse(
+            content=None,
+            tool_calls=[{
+                "name": "draft_followup_email",
+                "input": {"subject": "Follow up", "body": "Please provide details."},
+            }],
+            input_tokens=500, output_tokens=100, model="claude-sonnet-4-6",
+        )
+
+        draft_followup(db, rfq.id)
+
+        events = db.query(AuditEvent).filter(AuditEvent.rfq_id == rfq.id).all()
+        assert len(events) == 1
+        assert events[0].event_type == "followup_drafted"
+        assert events[0].actor == "validation_agent"
+        # C3: plain English, not jargon
+        assert "Draft follow-up prepared" in events[0].description
+        assert "what is being shipped" in events[0].description
+
+    @patch("backend.agents.validation.call_llm")
+    @patch("backend.agents.validation.start_run")
+    @patch("backend.agents.validation.finish_run")
+    @patch("backend.agents.validation.fail_run")
+    def test_llm_no_tool_call_fails_gracefully(self, mock_fail, mock_finish, mock_start, mock_llm, db):
+        """If the LLM doesn't call the tool, draft_followup returns None."""
+        rfq = _create_rfq(
+            db,
+            origin="A", commodity=None,
+            confidence_scores={"origin": 0.98, "destination": 0.0,
+                               "equipment_type": 0.0, "truck_count": 0.0,
+                               "commodity": 0.0, "weight_lbs": 0.0},
+        )
+
+        mock_run = MagicMock()
+        mock_run.id = 4
+        mock_start.return_value = mock_run
+        mock_llm.return_value = LLMResponse(
+            content="I can't draft this.", tool_calls=[],
+            input_tokens=100, output_tokens=50, model="claude-sonnet-4-6",
+        )
+
+        result = draft_followup(db, rfq.id)
+        assert result is None
+        mock_fail.assert_called_once()
+
+    def test_nonexistent_rfq_returns_none(self, db):
+        result = draft_followup(db, 99999)
+        assert result is None


### PR DESCRIPTION
## Summary
- `detect_missing_info()` identifies null required fields and low-confidence extractions (< 0.90)
- `draft_followup()` calls LLM to draft professional follow-up, persists as approval record (C2 — pending_approval)
- Required fields: origin, destination, equipment_type, truck_count, commodity. Recommended: weight, dates.
- 12 tests, 77/77 total pass

Closes #15

## Test plan
- [ ] `python -m pytest tests/test_validation_agent.py -v` — 12/12 pass
- [ ] `python -m pytest tests/ -v` — 77/77 pass
- [ ] Verify approval record has status=pending_approval (C2)
- [ ] Review required vs recommended field categorization
- [ ] Verify audit events use plain English (C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)