### PR TITLE
#16 — Generate structured quote sheet from inbound RFQ

### DIFF
--- a/backend/agents/quote_sheet.py
+++ b/backend/agents/quote_sheet.py
@@ -1,0 +1,254 @@
+"""
+backend/agents/quote_sheet.py — Structured quote sheet generator.
+
+Takes a complete RFQ (state=ready_to_quote) and produces a structured,
+carrier-facing quote sheet. This is the output artifact the broker reviews
+before sending to carriers — it transforms messy email data into a clean,
+professional format.
+
+Pipeline position:
+    Extraction (#24) creates RFQ -> Validation (#15) handles missing info
+    -> This agent packages the complete RFQ into a carrier-ready sheet
+    -> Carrier distribution (#32) sends it out
+
+The quote sheet is NOT an email draft — it's a structured data format that
+carrier distribution (#32) will use to compose personalized carrier emails.
+It's also what the broker sees in the RFQ detail view as the "quote summary."
+
+Called by:
+    - The background worker when an RFQ transitions to ready_to_quote
+    - Manually for testing: `generate_quote_sheet(db, rfq_id)`
+
+Cross-cutting constraints:
+    C3 — Sheet uses professional broker/carrier language
+    C4 — LLM call logged via agent_calls, run tracked via agent_runs
+    C5 — Cost caps enforced at call_llm level
+    FR-AG-5 — A structured quote sheet can be generated from a complete RFQ
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import AuditEvent, RFQ, RFQState
+from backend.llm.client import call_llm
+from backend.llm.provider import ToolDefinition
+from backend.services.agent_runs import fail_run, finish_run, start_run
+
+logger = logging.getLogger("golteris.agents.quote_sheet")
+
+
+# ---------------------------------------------------------------------------
+# Tool-use schema — the LLM returns a structured quote sheet
+# ---------------------------------------------------------------------------
+
+QUOTE_SHEET_TOOL = ToolDefinition(
+    name="generate_quote_sheet",
+    description=(
+        "Generate a structured freight quote sheet from RFQ data. The sheet is "
+        "formatted for carrier distribution — it's what carriers receive when "
+        "the broker sends out a request for pricing."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "reference_id": {
+                "type": "string",
+                "description": "Quote reference number (e.g., 'BLT-2026-0042')",
+            },
+            "summary": {
+                "type": "string",
+                "description": "One-line summary of the load (e.g., '3 flatbeds, Dallas TX to Atlanta GA, steel coils')",
+            },
+            "lanes": {
+                "type": "array",
+                "description": "One entry per lane (origin-destination pair). Most RFQs have one lane.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "origin": {"type": "string", "description": "Pickup city, state"},
+                        "destination": {"type": "string", "description": "Delivery city, state"},
+                        "equipment": {"type": "string", "description": "Truck/trailer type"},
+                        "truck_count": {"type": "integer", "description": "Number of trucks for this lane"},
+                        "commodity": {"type": "string", "description": "What is being shipped"},
+                        "weight_lbs": {"type": ["integer", "null"], "description": "Weight per truck in lbs"},
+                        "pickup_date": {"type": ["string", "null"], "description": "Pickup date or window"},
+                        "delivery_date": {"type": ["string", "null"], "description": "Delivery date or window"},
+                    },
+                    "required": ["origin", "destination", "equipment", "truck_count", "commodity"],
+                },
+            },
+            "special_requirements": {
+                "type": ["string", "null"],
+                "description": "Any special requirements: tarping, permits, lift gate, temperature, insurance, etc.",
+            },
+            "notes": {
+                "type": ["string", "null"],
+                "description": "Additional notes for carriers (e.g., tight yard access, appointment required)",
+            },
+            "response_deadline": {
+                "type": ["string", "null"],
+                "description": "When the broker needs rates back by",
+            },
+        },
+        "required": ["reference_id", "summary", "lanes"],
+    },
+)
+
+
+SYSTEM_PROMPT = """You are a freight broker assistant creating a structured quote sheet from RFQ data. The quote sheet will be sent to carriers to request pricing.
+
+Rules:
+- Format the data clearly and professionally — this is what carriers see.
+- Create a reference ID in the format BLT-YYYY-NNNN (year + RFQ ID zero-padded).
+- Write a concise one-line summary: "[truck_count] [equipment], [origin] to [destination], [commodity]"
+- Organize into lanes (one per origin-destination pair). Most RFQs are single-lane.
+- Include all special requirements — carriers need this to quote accurately.
+- Add practical notes that help carriers (yard access issues, appointment windows, etc.).
+- If pickup is soon (within 3 days), note urgency in the response_deadline.
+- Use standard freight industry terminology.
+
+Use the generate_quote_sheet tool to return the structured sheet."""
+
+
+def generate_quote_sheet(
+    db: Session,
+    rfq_id: int,
+) -> Optional[dict[str, Any]]:
+    """
+    Generate a structured quote sheet from a complete RFQ.
+
+    Only works for RFQs in ready_to_quote state — if the RFQ still needs
+    clarification, the quote sheet would be incomplete and misleading.
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ to generate a sheet for.
+
+    Returns:
+        The structured quote sheet as a dict (matches QUOTE_SHEET_TOOL schema),
+        or None if the RFQ doesn't exist or isn't ready.
+
+    Side effects:
+        - Creates an agent_run and agent_calls for traceability (C4)
+        - Creates an audit event for the RFQ timeline
+    """
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        logger.error("RFQ %d not found", rfq_id)
+        return None
+
+    # Only generate sheets for RFQs that are ready to quote
+    if rfq.state != RFQState.READY_TO_QUOTE:
+        logger.warning(
+            "RFQ %d is in %s state, not ready_to_quote — cannot generate quote sheet",
+            rfq_id, rfq.state.value,
+        )
+        return None
+
+    run = start_run(
+        db,
+        workflow_name="Quote Sheet Generation",
+        rfq_id=rfq_id,
+        trigger_source="state_ready_to_quote",
+    )
+
+    try:
+        user_prompt = _build_user_prompt(rfq)
+
+        response = call_llm(
+            db=db,
+            run_id=run.id,
+            agent_name="quote_sheet",
+            system_prompt=SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            tools=[QUOTE_SHEET_TOOL],
+            temperature=0.0,
+        )
+
+        sheet = _parse_tool_response(response)
+        if not sheet:
+            logger.warning("LLM did not call generate_quote_sheet tool for RFQ %d", rfq_id)
+            fail_run(db, run.id, "LLM did not return tool-use result")
+            return None
+
+        # Log audit event — plain English per C3
+        _log_audit_event(db, rfq, sheet)
+
+        db.commit()
+        finish_run(db, run.id)
+
+        logger.info(
+            "Quote sheet generated for RFQ %d: %s",
+            rfq_id, sheet.get("summary", ""),
+        )
+
+        return sheet
+
+    except Exception as e:
+        logger.exception("Quote sheet generation failed for RFQ %d: %s", rfq_id, e)
+        fail_run(db, run.id, str(e))
+        raise
+
+
+def _build_user_prompt(rfq: RFQ) -> str:
+    """
+    Build the user prompt from the RFQ data.
+
+    Provides all extracted fields so the LLM can structure them into
+    a professional carrier-facing format.
+    """
+    lines = [
+        f"RFQ ID: {rfq.id}",
+        f"Customer: {rfq.customer_name or 'Unknown'} at {rfq.customer_company or 'Unknown'}",
+        f"Origin: {rfq.origin or 'Not specified'}",
+        f"Destination: {rfq.destination or 'Not specified'}",
+        f"Equipment: {rfq.equipment_type or 'Not specified'}",
+        f"Truck count: {rfq.truck_count or 'Not specified'}",
+        f"Commodity: {rfq.commodity or 'Not specified'}",
+        f"Weight: {rfq.weight_lbs} lbs" if rfq.weight_lbs else "Weight: Not specified",
+        f"Pickup date: {rfq.pickup_date.strftime('%Y-%m-%d') if rfq.pickup_date else 'Not specified'}",
+        f"Delivery date: {rfq.delivery_date.strftime('%Y-%m-%d') if rfq.delivery_date else 'Not specified'}",
+        f"Special requirements: {rfq.special_requirements or 'None'}",
+        f"Today's date: {datetime.utcnow().strftime('%Y-%m-%d')}",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_tool_response(response) -> Optional[dict[str, Any]]:
+    """Extract the structured quote sheet from the LLM's tool-use response."""
+    if not response.tool_calls:
+        return None
+
+    for tool_call in response.tool_calls:
+        if tool_call.get("name") == "generate_quote_sheet":
+            return tool_call.get("input", {})
+
+    return None
+
+
+def _log_audit_event(db: Session, rfq: RFQ, sheet: dict) -> None:
+    """
+    Create an audit event for the RFQ timeline (C3 — plain English).
+
+    The broker sees "Quote sheet prepared — ready for carrier distribution"
+    not "quote_sheet_agent_completed."
+    """
+    lane_count = len(sheet.get("lanes", []))
+    summary = sheet.get("summary", "")
+
+    event = AuditEvent(
+        rfq_id=rfq.id,
+        event_type="quote_sheet_generated",
+        actor="quote_sheet_agent",
+        description=f"Quote sheet prepared — {summary}",
+        event_data={
+            "reference_id": sheet.get("reference_id"),
+            "lane_count": lane_count,
+            "has_special_requirements": bool(sheet.get("special_requirements")),
+        },
+    )
+    db.add(event)

--- a/tests/test_quote_sheet.py
+++ b/tests/test_quote_sheet.py
@@ -1,0 +1,277 @@
+"""
+tests/test_quote_sheet.py — Tests for quote sheet generation (#16).
+
+Verifies the three acceptance criteria:
+    1. A sample inbound email can produce a usable structured sheet
+    2. The generated output contains the fields the broker needs
+    3. The output is stable enough for demo use
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.agents.quote_sheet import QUOTE_SHEET_TOOL, generate_quote_sheet
+from backend.db.models import AuditEvent, Base, RFQ, RFQState
+from backend.llm.provider import LLMResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_compatible():
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _create_rfq(db, state=RFQState.READY_TO_QUOTE, **kwargs) -> RFQ:
+    defaults = {
+        "customer_name": "Tom Reynolds",
+        "customer_company": "Acme Logistics",
+        "customer_email": "tom@acme.com",
+        "origin": "Dallas, TX",
+        "destination": "Atlanta, GA",
+        "equipment_type": "Flatbed",
+        "truck_count": 1,
+        "commodity": "Steel coils",
+        "weight_lbs": 42000,
+        "pickup_date": datetime(2026, 4, 15),
+        "delivery_date": datetime(2026, 4, 17),
+        "special_requirements": "Tarping required",
+        "state": state,
+    }
+    defaults.update(kwargs)
+    rfq = RFQ(**defaults)
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+def _mock_sheet_response(rfq_id: int) -> LLMResponse:
+    """Build a mock LLM response with a realistic quote sheet."""
+    return LLMResponse(
+        content=None,
+        tool_calls=[{
+            "name": "generate_quote_sheet",
+            "input": {
+                "reference_id": f"BLT-2026-{rfq_id:04d}",
+                "summary": "1 flatbed, Dallas TX to Atlanta GA, steel coils",
+                "lanes": [{
+                    "origin": "Dallas, TX",
+                    "destination": "Atlanta, GA",
+                    "equipment": "Flatbed (48ft)",
+                    "truck_count": 1,
+                    "commodity": "Steel coils",
+                    "weight_lbs": 42000,
+                    "pickup_date": "2026-04-15",
+                    "delivery_date": "2026-04-17",
+                }],
+                "special_requirements": "Tarping required",
+                "notes": None,
+                "response_deadline": "2026-04-12",
+            },
+        }],
+        input_tokens=800,
+        output_tokens=250,
+        model="claude-sonnet-4-6",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolSchema:
+    def test_schema_requires_core_fields(self):
+        required = QUOTE_SHEET_TOOL.input_schema["required"]
+        assert "reference_id" in required
+        assert "summary" in required
+        assert "lanes" in required
+
+    def test_lane_schema_requires_core_fields(self):
+        lane_required = QUOTE_SHEET_TOOL.input_schema["properties"]["lanes"]["items"]["required"]
+        assert "origin" in lane_required
+        assert "destination" in lane_required
+        assert "equipment" in lane_required
+        assert "truck_count" in lane_required
+        assert "commodity" in lane_required
+
+
+# ---------------------------------------------------------------------------
+# Quote sheet generation tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateQuoteSheet:
+
+    @patch("backend.agents.quote_sheet.call_llm")
+    @patch("backend.agents.quote_sheet.start_run")
+    @patch("backend.agents.quote_sheet.finish_run")
+    def test_happy_path_generates_sheet(self, mock_finish, mock_start, mock_llm, db):
+        """Complete RFQ in ready_to_quote -> structured quote sheet."""
+        rfq = _create_rfq(db)
+
+        mock_run = MagicMock()
+        mock_run.id = 1
+        mock_start.return_value = mock_run
+        mock_llm.return_value = _mock_sheet_response(rfq.id)
+
+        sheet = generate_quote_sheet(db, rfq.id)
+
+        assert sheet is not None
+        assert sheet["reference_id"] == f"BLT-2026-{rfq.id:04d}"
+        assert "flatbed" in sheet["summary"].lower()
+        assert "Dallas" in sheet["summary"]
+        assert len(sheet["lanes"]) == 1
+        assert sheet["lanes"][0]["origin"] == "Dallas, TX"
+        assert sheet["lanes"][0]["destination"] == "Atlanta, GA"
+        assert sheet["lanes"][0]["truck_count"] == 1
+        assert sheet["lanes"][0]["commodity"] == "Steel coils"
+        assert sheet["special_requirements"] == "Tarping required"
+
+    @patch("backend.agents.quote_sheet.call_llm")
+    @patch("backend.agents.quote_sheet.start_run")
+    @patch("backend.agents.quote_sheet.finish_run")
+    def test_multi_truck_generates_sheet(self, mock_finish, mock_start, mock_llm, db):
+        """Multi-truck RFQ should produce a sheet with correct truck count."""
+        rfq = _create_rfq(
+            db,
+            origin="Houston, TX",
+            destination="Memphis, TN",
+            equipment_type="Flatbed",
+            truck_count=3,
+            commodity="Construction equipment",
+            weight_lbs=44000,
+            special_requirements="Tarping required, Oversize permits needed",
+        )
+
+        mock_run = MagicMock()
+        mock_run.id = 2
+        mock_start.return_value = mock_run
+        mock_llm.return_value = LLMResponse(
+            content=None,
+            tool_calls=[{
+                "name": "generate_quote_sheet",
+                "input": {
+                    "reference_id": f"BLT-2026-{rfq.id:04d}",
+                    "summary": "3 flatbeds, Houston TX to Memphis TN, construction equipment",
+                    "lanes": [{
+                        "origin": "Houston, TX",
+                        "destination": "Memphis, TN",
+                        "equipment": "Flatbed",
+                        "truck_count": 3,
+                        "commodity": "Construction equipment",
+                        "weight_lbs": 44000,
+                        "pickup_date": "2026-04-20",
+                        "delivery_date": "2026-04-25",
+                    }],
+                    "special_requirements": "Tarping required. Oversize permits needed.",
+                    "notes": "All 3 trucks same pickup window",
+                    "response_deadline": None,
+                },
+            }],
+            input_tokens=900,
+            output_tokens=280,
+            model="claude-sonnet-4-6",
+        )
+
+        sheet = generate_quote_sheet(db, rfq.id)
+
+        assert sheet is not None
+        assert sheet["lanes"][0]["truck_count"] == 3
+        assert "Oversize" in sheet["special_requirements"]
+
+    def test_refuses_needs_clarification_state(self, db):
+        """RFQ in needs_clarification should NOT generate a sheet."""
+        rfq = _create_rfq(db, state=RFQState.NEEDS_CLARIFICATION)
+        result = generate_quote_sheet(db, rfq.id)
+        assert result is None
+
+    def test_refuses_nonexistent_rfq(self, db):
+        result = generate_quote_sheet(db, 99999)
+        assert result is None
+
+    @patch("backend.agents.quote_sheet.call_llm")
+    @patch("backend.agents.quote_sheet.start_run")
+    @patch("backend.agents.quote_sheet.finish_run")
+    def test_audit_event_created(self, mock_finish, mock_start, mock_llm, db):
+        """Quote sheet generation should log a plain-English audit event (C3)."""
+        rfq = _create_rfq(db)
+
+        mock_run = MagicMock()
+        mock_run.id = 3
+        mock_start.return_value = mock_run
+        mock_llm.return_value = _mock_sheet_response(rfq.id)
+
+        generate_quote_sheet(db, rfq.id)
+
+        events = db.query(AuditEvent).filter(AuditEvent.rfq_id == rfq.id).all()
+        assert len(events) == 1
+        assert events[0].event_type == "quote_sheet_generated"
+        assert events[0].actor == "quote_sheet_agent"
+        assert "Quote sheet prepared" in events[0].description
+
+    @patch("backend.agents.quote_sheet.call_llm")
+    @patch("backend.agents.quote_sheet.start_run")
+    @patch("backend.agents.quote_sheet.finish_run")
+    @patch("backend.agents.quote_sheet.fail_run")
+    def test_no_tool_call_fails_gracefully(self, mock_fail, mock_finish, mock_start, mock_llm, db):
+        rfq = _create_rfq(db)
+
+        mock_run = MagicMock()
+        mock_run.id = 4
+        mock_start.return_value = mock_run
+        mock_llm.return_value = LLMResponse(
+            content="Here's a quote sheet...", tool_calls=[],
+            input_tokens=500, output_tokens=200, model="claude-sonnet-4-6",
+        )
+
+        result = generate_quote_sheet(db, rfq.id)
+        assert result is None
+        mock_fail.assert_called_once()
+
+    @patch("backend.agents.quote_sheet.call_llm")
+    @patch("backend.agents.quote_sheet.start_run")
+    @patch("backend.agents.quote_sheet.finish_run")
+    def test_sheet_contains_all_carrier_fields(self, mock_finish, mock_start, mock_llm, db):
+        """The sheet must contain everything a carrier needs to quote."""
+        rfq = _create_rfq(db)
+
+        mock_run = MagicMock()
+        mock_run.id = 5
+        mock_start.return_value = mock_run
+        mock_llm.return_value = _mock_sheet_response(rfq.id)
+
+        sheet = generate_quote_sheet(db, rfq.id)
+
+        # Carrier-essential fields
+        assert "reference_id" in sheet
+        assert "summary" in sheet
+        assert "lanes" in sheet
+        lane = sheet["lanes"][0]
+        assert "origin" in lane
+        assert "destination" in lane
+        assert "equipment" in lane
+        assert "truck_count" in lane
+        assert "commodity" in lane


### PR DESCRIPTION
## Summary
- Quote sheet generator (`backend/agents/quote_sheet.py`) using LLM tool-use
- Structured output: reference ID, summary, lanes[], special requirements, carrier notes
- State guard: only generates for ready_to_quote RFQs
- 9 tests, 86/86 total pass

Closes #16

## Test plan
- [ ] `python -m pytest tests/test_quote_sheet.py -v` — 9/9 pass
- [ ] `python -m pytest tests/ -v` — 86/86 pass
- [ ] Review tool schema for carrier-facing completeness
- [ ] Verify state guard rejects wrong-state RFQs

🤖 Generated with [Claude Code](https://claude.com/claude-code)