### PR TITLE
#13 — Build message-to-RFQ matching service

### DIFF
--- a/backend/services/message_matching.py
+++ b/backend/services/message_matching.py
@@ -1,0 +1,377 @@
+"""
+backend/services/message_matching.py — Message-to-RFQ matching service.
+
+When a new inbound message arrives, this service determines which RFQ it
+belongs to (or whether it's a new RFQ / noise). It uses a tiered strategy:
+
+    1. Thread matching (deterministic) — if the message has in_reply_to or
+       thread_id that matches an existing message, attach to the same RFQ.
+       This handles direct replies to our outbound emails.
+
+    2. Sender matching — find active RFQs where the customer_email matches
+       the message sender. If exactly one match, attach with high confidence.
+
+    3. Context scoring — when multiple candidates exist, score them by
+       comparing route keywords, equipment type, dates, and subject overlap.
+       The highest-scoring candidate wins if above threshold.
+
+    4. Review queue — if no strategy produces a confident match, the message
+       goes to the review queue for the broker to resolve manually (FR-EI-4).
+
+Called by:
+    - The background worker after ingesting a new message
+    - The email ingestion pipeline (#12)
+
+Cross-cutting constraints:
+    FR-EI-3 — Every inbound message attached via thread matching first, context scoring second
+    FR-EI-4 — Ambiguous matches do NOT auto-attach; they enter the review queue
+    FR-EI-5 — Message routing_status is set for the Inbox view badges
+    C4 — Match reason stored in audit_events for traceability
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import (
+    AuditEvent,
+    Message,
+    MessageRoutingStatus,
+    ReviewQueue,
+    ReviewQueueStatus,
+    RFQ,
+    RFQState,
+)
+
+logger = logging.getLogger("golteris.services.message_matching")
+
+# Confidence thresholds for auto-attach vs review queue
+AUTO_ATTACH_THRESHOLD = 0.85
+REVIEW_THRESHOLD = 0.30  # Below this, treat as new RFQ
+
+# Terminal RFQ states — don't match messages to closed RFQs
+TERMINAL_STATES = {RFQState.WON, RFQState.LOST, RFQState.CANCELLED}
+
+
+@dataclass
+class MatchCandidate:
+    """A potential RFQ that a message could belong to, with a confidence score."""
+    rfq_id: int
+    score: float
+    method: str  # "thread", "sender", "context"
+    reason: str  # Human-readable explanation of why this was a match
+
+
+@dataclass
+class MatchResult:
+    """The outcome of attempting to match a message to an RFQ."""
+    rfq_id: Optional[int] = None
+    confidence: float = 0.0
+    method: str = "none"
+    reason: str = ""
+    candidates: list[MatchCandidate] = field(default_factory=list)
+    routing_status: MessageRoutingStatus = MessageRoutingStatus.NEEDS_REVIEW
+
+
+def match_message_to_rfq(db: Session, message_id: int) -> MatchResult:
+    """
+    Determine which RFQ an inbound message belongs to.
+
+    Tries matching strategies in priority order: thread -> sender -> context.
+    Updates the message's routing_status and rfq_id based on the result.
+    Creates review_queue entries for ambiguous matches (FR-EI-4).
+
+    Args:
+        db: SQLAlchemy session.
+        message_id: The inbound message to match.
+
+    Returns:
+        MatchResult with the outcome (rfq_id, confidence, method, routing_status).
+        If no match, rfq_id is None and routing_status indicates what happened.
+    """
+    message = db.query(Message).filter(Message.id == message_id).first()
+    if not message:
+        logger.error("Message %d not found", message_id)
+        return MatchResult(reason="Message not found")
+
+    # Strategy 1: Thread matching (deterministic, highest priority)
+    result = _try_thread_match(db, message)
+    if result.rfq_id:
+        _apply_match(db, message, result)
+        return result
+
+    # Strategy 2: Sender matching against active RFQs
+    candidates = _find_sender_candidates(db, message)
+
+    if candidates:
+        # Strategy 3: Context scoring to refine all candidates
+        scored = _score_candidates(db, message, candidates)
+        best = max(scored, key=lambda c: c.score)
+
+        if best.score >= AUTO_ATTACH_THRESHOLD:
+            # Strong match — auto-attach
+            result = MatchResult(
+                rfq_id=best.rfq_id,
+                confidence=best.score,
+                method=best.method,
+                reason=best.reason,
+                candidates=scored,
+                routing_status=MessageRoutingStatus.ATTACHED,
+            )
+            _apply_match(db, message, result)
+            return result
+
+        if len(scored) > 1:
+            # Multiple candidates, none strong enough — review queue (FR-EI-4)
+            result = MatchResult(
+                confidence=best.score,
+                method="ambiguous",
+                reason=f"Multiple candidates, best score {best.score:.2f} below threshold",
+                candidates=scored,
+                routing_status=MessageRoutingStatus.NEEDS_REVIEW,
+            )
+            _send_to_review_queue(db, message, result)
+            return result
+
+        # Single weak match — review queue
+        result = MatchResult(
+            confidence=best.score,
+            method="weak_sender",
+            reason=f"Single sender match but confidence {best.score:.2f} below threshold",
+            candidates=scored,
+            routing_status=MessageRoutingStatus.NEEDS_REVIEW,
+        )
+        _send_to_review_queue(db, message, result)
+        return result
+
+    # No candidates at all — this is likely a new RFQ
+    result = MatchResult(
+        method="no_match",
+        reason="No matching RFQs found — likely a new quote request",
+        routing_status=MessageRoutingStatus.NEW_RFQ_CREATED,
+    )
+    message.routing_status = result.routing_status
+    db.commit()
+
+    logger.info("Message %d: no match — flagged as new RFQ", message_id)
+    return result
+
+
+def _try_thread_match(db: Session, message: Message) -> MatchResult:
+    """
+    Try to match via thread_id or in_reply_to (deterministic matching).
+
+    If the message has an in_reply_to header, look for the parent message
+    and use its RFQ. If it has a thread_id, look for any message in that
+    thread that's already attached to an RFQ.
+
+    This is the highest-confidence match — it's based on email headers,
+    not content analysis.
+    """
+    # Try in_reply_to first — most reliable for direct replies
+    if message.in_reply_to:
+        parent = (
+            db.query(Message)
+            .filter(Message.message_id_header == message.in_reply_to)
+            .first()
+        )
+        if parent and parent.rfq_id:
+            return MatchResult(
+                rfq_id=parent.rfq_id,
+                confidence=0.99,
+                method="thread_reply",
+                reason=f"Direct reply to message in RFQ #{parent.rfq_id}",
+                routing_status=MessageRoutingStatus.ATTACHED,
+            )
+
+    # Try thread_id — for messages in the same conversation
+    if message.thread_id:
+        thread_msg = (
+            db.query(Message)
+            .filter(
+                Message.thread_id == message.thread_id,
+                Message.rfq_id.isnot(None),
+                Message.id != message.id,
+            )
+            .first()
+        )
+        if thread_msg and thread_msg.rfq_id:
+            return MatchResult(
+                rfq_id=thread_msg.rfq_id,
+                confidence=0.97,
+                method="thread_id",
+                reason=f"Same thread as message attached to RFQ #{thread_msg.rfq_id}",
+                routing_status=MessageRoutingStatus.ATTACHED,
+            )
+
+    return MatchResult()  # No thread match
+
+
+def _find_sender_candidates(db: Session, message: Message) -> list[MatchCandidate]:
+    """
+    Find active RFQs where the customer_email matches the message sender.
+
+    Only considers non-terminal RFQs (not won/lost/cancelled) since a new
+    message from a customer with a closed RFQ is likely a new request.
+    """
+    # Normalize sender to just the email address
+    sender_email = _extract_email(message.sender)
+    if not sender_email:
+        return []
+
+    active_rfqs = (
+        db.query(RFQ)
+        .filter(
+            RFQ.customer_email == sender_email,
+            RFQ.state.notin_([s.value for s in TERMINAL_STATES]),
+        )
+        .all()
+    )
+
+    return [
+        MatchCandidate(
+            rfq_id=rfq.id,
+            score=0.70,  # Base score for sender match — context scoring refines it
+            method="sender",
+            reason=f"Same sender ({sender_email}) as RFQ #{rfq.id}",
+        )
+        for rfq in active_rfqs
+    ]
+
+
+def _score_candidates(
+    db: Session,
+    message: Message,
+    candidates: list[MatchCandidate],
+) -> list[MatchCandidate]:
+    """
+    Refine candidate scores using context signals from the message content.
+
+    Boosts scores when the message mentions route/equipment/commodity that
+    match the candidate RFQ. This helps disambiguate when a customer has
+    multiple active RFQs.
+
+    Scoring adjustments (additive):
+    - Subject keyword overlap with RFQ route: +0.10
+    - Body mentions origin or destination: +0.08 each
+    - Body mentions equipment type: +0.05
+    - Body mentions commodity: +0.05
+    """
+    for candidate in candidates:
+        # This is a simple scoring approach — no LLM needed.
+        # For the MVP, keyword matching is sufficient. More sophisticated
+        # scoring (embeddings, LLM context) can come later.
+        rfq = db.query(RFQ).filter(RFQ.id == candidate.rfq_id).first()
+        if not rfq:
+            continue
+
+        body_lower = (message.body or "").lower()
+        subject_lower = (message.subject or "").lower()
+
+        # Route keywords in subject
+        if rfq.origin and rfq.origin.lower().split(",")[0] in subject_lower:
+            candidate.score += 0.10
+        if rfq.destination and rfq.destination.lower().split(",")[0] in subject_lower:
+            candidate.score += 0.10
+
+        # Route keywords in body
+        if rfq.origin and rfq.origin.lower().split(",")[0] in body_lower:
+            candidate.score += 0.08
+        if rfq.destination and rfq.destination.lower().split(",")[0] in body_lower:
+            candidate.score += 0.08
+
+        # Equipment match
+        if rfq.equipment_type and rfq.equipment_type.lower() in body_lower:
+            candidate.score += 0.05
+
+        # Commodity match
+        if rfq.commodity and rfq.commodity.lower() in body_lower:
+            candidate.score += 0.05
+
+        candidate.reason += f" (context score: {candidate.score:.2f})"
+
+    return candidates
+
+
+def _apply_match(db: Session, message: Message, result: MatchResult) -> None:
+    """
+    Apply a successful match — link message to RFQ and log the audit event.
+    """
+    message.rfq_id = result.rfq_id
+    message.routing_status = result.routing_status
+
+    # Audit event for traceability (C4)
+    event = AuditEvent(
+        rfq_id=result.rfq_id,
+        event_type="message_matched",
+        actor="matching_service",
+        description=f"Inbound message attached — {result.reason}",
+        event_data={
+            "message_id": message.id,
+            "method": result.method,
+            "confidence": result.confidence,
+            "candidate_count": len(result.candidates),
+        },
+    )
+    db.add(event)
+    db.commit()
+
+    logger.info(
+        "Message %d matched to RFQ %d (method=%s, confidence=%.2f)",
+        message.id, result.rfq_id, result.method, result.confidence,
+    )
+
+
+def _send_to_review_queue(db: Session, message: Message, result: MatchResult) -> None:
+    """
+    Put an ambiguous message into the review queue for the broker (FR-EI-4).
+
+    The broker sees this in the Inbox view as a "Needs review" badge and
+    can manually assign it to an RFQ or create a new one.
+    """
+    message.routing_status = MessageRoutingStatus.NEEDS_REVIEW
+
+    review_entry = ReviewQueue(
+        message_id=message.id,
+        candidates=[
+            {"rfq_id": c.rfq_id, "score": c.score, "reason": c.reason}
+            for c in result.candidates
+        ],
+        reason=result.reason,
+        status=ReviewQueueStatus.PENDING,
+    )
+    db.add(review_entry)
+    db.commit()
+
+    logger.info(
+        "Message %d sent to review queue: %d candidates, reason=%s",
+        message.id, len(result.candidates), result.reason,
+    )
+
+
+def _extract_email(sender: str) -> Optional[str]:
+    """
+    Extract the email address from a sender string.
+
+    Handles formats like:
+    - "tom@example.com"
+    - "Tom Reynolds <tom@example.com>"
+    - "tom@example.com (Tom Reynolds)"
+    """
+    if not sender:
+        return None
+
+    # Try angle bracket format first: "Name <email>"
+    match = re.search(r"<([^>]+)>", sender)
+    if match:
+        return match.group(1).lower().strip()
+
+    # Try bare email
+    match = re.search(r"[\w.+-]+@[\w-]+\.[\w.]+", sender)
+    if match:
+        return match.group(0).lower().strip()
+
+    return sender.lower().strip()

--- a/tests/test_message_matching.py
+++ b/tests/test_message_matching.py
@@ -1,0 +1,305 @@
+"""
+tests/test_message_matching.py — Tests for message-to-RFQ matching (#13).
+
+Verifies the four acceptance criteria:
+    1. Deterministic reply matches attach automatically
+    2. Non-deterministic messages are scored against active RFQs
+    3. Ambiguous matches do not auto-attach silently
+    4. Match reason is stored for auditability
+"""
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.db.models import (
+    AuditEvent,
+    Base,
+    Message,
+    MessageDirection,
+    MessageRoutingStatus,
+    ReviewQueue,
+    RFQ,
+    RFQState,
+)
+from backend.services.message_matching import (
+    MatchResult,
+    _extract_email,
+    match_message_to_rfq,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_compatible():
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _create_message(db, sender, subject="Test", body="Test body", **kwargs) -> Message:
+    msg = Message(
+        sender=sender,
+        subject=subject,
+        body=body,
+        direction=MessageDirection.INBOUND,
+        **kwargs,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+def _create_rfq(db, customer_email, state=RFQState.NEEDS_CLARIFICATION, **kwargs) -> RFQ:
+    defaults = {
+        "customer_name": "Test",
+        "customer_email": customer_email,
+        "state": state,
+    }
+    defaults.update(kwargs)
+    rfq = RFQ(**defaults)
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+# ---------------------------------------------------------------------------
+# Thread matching tests (deterministic)
+# ---------------------------------------------------------------------------
+
+
+class TestThreadMatching:
+    """Acceptance criterion: deterministic reply matches attach automatically."""
+
+    def test_in_reply_to_matches_parent(self, db):
+        """Reply with in_reply_to header -> attaches to parent's RFQ."""
+        rfq = _create_rfq(db, "mike@prairie.com")
+        original = _create_message(
+            db, "mike@prairie.com", "Need a truck",
+            message_id_header="<msg-003@prairie.com>",
+            rfq_id=rfq.id,
+        )
+
+        reply = _create_message(
+            db, "mike@prairie.com", "Re: Need a truck",
+            body="Here's the missing commodity info: auto parts",
+            in_reply_to="<msg-003@prairie.com>",
+            message_id_header="<msg-007@prairie.com>",
+        )
+
+        result = match_message_to_rfq(db, reply.id)
+
+        assert result.rfq_id == rfq.id
+        assert result.confidence == 0.99
+        assert result.method == "thread_reply"
+        assert reply.routing_status == MessageRoutingStatus.ATTACHED
+
+    def test_thread_id_matches_sibling(self, db):
+        """Message with same thread_id as an existing message -> attaches to same RFQ."""
+        rfq = _create_rfq(db, "sarah@global.com")
+        first_msg = _create_message(
+            db, "sarah@global.com", "Quote request",
+            thread_id="thread-002",
+            message_id_header="<msg-002@global.com>",
+            rfq_id=rfq.id,
+        )
+
+        follow_up = _create_message(
+            db, "sarah@global.com", "Re: Quote request",
+            body="Adding more details",
+            thread_id="thread-002",
+            message_id_header="<msg-002b@global.com>",
+        )
+
+        result = match_message_to_rfq(db, follow_up.id)
+
+        assert result.rfq_id == rfq.id
+        assert result.confidence == 0.97
+        assert result.method == "thread_id"
+
+
+# ---------------------------------------------------------------------------
+# Sender matching tests
+# ---------------------------------------------------------------------------
+
+
+class TestSenderMatching:
+    """Acceptance criterion: non-deterministic messages scored against active RFQs."""
+
+    def test_single_active_rfq_auto_attaches(self, db):
+        """One active RFQ from this sender + context match -> auto-attach."""
+        rfq = _create_rfq(
+            db, "tom@acme.com",
+            origin="Dallas, TX", destination="Atlanta, GA",
+            equipment_type="Flatbed",
+        )
+        msg = _create_message(
+            db, "tom@acme.com", "Updated weight info",
+            body="The Dallas to Atlanta flatbed load is actually 44,000 lbs",
+        )
+
+        result = match_message_to_rfq(db, msg.id)
+
+        # Sender match (0.70) + origin in body (0.08) + destination in body (0.08)
+        # + equipment in body (0.05) = 0.91 >= 0.85 threshold
+        assert result.rfq_id == rfq.id
+        assert result.routing_status == MessageRoutingStatus.ATTACHED
+
+    def test_no_active_rfqs_flags_new(self, db):
+        """No matching RFQs -> flagged as new RFQ."""
+        msg = _create_message(
+            db, "newcustomer@example.com", "Quote request",
+            body="Need a van from LA to SF",
+        )
+
+        result = match_message_to_rfq(db, msg.id)
+
+        assert result.rfq_id is None
+        assert result.routing_status == MessageRoutingStatus.NEW_RFQ_CREATED
+        assert result.method == "no_match"
+
+    def test_closed_rfqs_ignored(self, db):
+        """Won/lost/cancelled RFQs should not be matched."""
+        _create_rfq(db, "tom@acme.com", state=RFQState.WON)
+        msg = _create_message(
+            db, "tom@acme.com", "New request",
+            body="Need a new quote for something else",
+        )
+
+        result = match_message_to_rfq(db, msg.id)
+
+        assert result.rfq_id is None
+        assert result.routing_status == MessageRoutingStatus.NEW_RFQ_CREATED
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous matching tests
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousMatching:
+    """Acceptance criterion: ambiguous matches do not auto-attach silently."""
+
+    def test_multiple_rfqs_same_sender_goes_to_review(self, db):
+        """Two active RFQs from same sender, no strong context signal -> review queue."""
+        _create_rfq(db, "sarah@global.com", origin="Houston, TX", destination="Memphis, TN")
+        _create_rfq(db, "sarah@global.com", origin="Houston, TX", destination="Nashville, TN")
+
+        msg = _create_message(
+            db, "sarah@global.com", "Update on the project",
+            body="Just wanted to check on the status",
+        )
+
+        result = match_message_to_rfq(db, msg.id)
+
+        assert result.rfq_id is None
+        assert result.routing_status == MessageRoutingStatus.NEEDS_REVIEW
+        assert len(result.candidates) == 2
+
+        # Verify review queue entry was created (FR-EI-4)
+        review = db.query(ReviewQueue).filter(ReviewQueue.message_id == msg.id).first()
+        assert review is not None
+        assert review.status.value == "pending"
+        assert len(review.candidates) == 2
+
+    def test_weak_single_match_goes_to_review(self, db):
+        """Single sender match but no context boost -> stays below threshold -> review."""
+        _create_rfq(db, "someone@company.com", origin="NYC", destination="Boston")
+        msg = _create_message(
+            db, "someone@company.com", "Hey",
+            body="Just following up on something",  # No route/equipment keywords
+        )
+
+        result = match_message_to_rfq(db, msg.id)
+
+        # Base sender score is 0.70, no context boosts -> below 0.85 threshold
+        assert result.routing_status == MessageRoutingStatus.NEEDS_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# Audit and reason storage tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditability:
+    """Acceptance criterion: match reason is stored for auditability."""
+
+    def test_successful_match_creates_audit_event(self, db):
+        """A successful match should log an audit event with the reason."""
+        rfq = _create_rfq(db, "tom@acme.com", origin="Dallas, TX", destination="Atlanta, GA")
+        original = _create_message(
+            db, "tom@acme.com", "Original request",
+            message_id_header="<orig@acme.com>",
+            rfq_id=rfq.id,
+        )
+        reply = _create_message(
+            db, "tom@acme.com", "Re: Original request",
+            in_reply_to="<orig@acme.com>",
+            message_id_header="<reply@acme.com>",
+        )
+
+        match_message_to_rfq(db, reply.id)
+
+        events = db.query(AuditEvent).filter(
+            AuditEvent.rfq_id == rfq.id,
+            AuditEvent.event_type == "message_matched",
+        ).all()
+        assert len(events) == 1
+        assert "thread_reply" in events[0].event_data["method"]
+        assert events[0].event_data["confidence"] == 0.99
+
+    def test_review_queue_stores_candidates_with_reasons(self, db):
+        """Review queue entries should include candidate RFQs with scores and reasons."""
+        rfq1 = _create_rfq(db, "multi@company.com", origin="Portland, OR")
+        rfq2 = _create_rfq(db, "multi@company.com", origin="Seattle, WA")
+        msg = _create_message(db, "multi@company.com", "Update", body="just checking in on status")
+
+        match_message_to_rfq(db, msg.id)
+
+        review = db.query(ReviewQueue).filter(ReviewQueue.message_id == msg.id).first()
+        assert review is not None
+        # Each candidate has rfq_id, score, and reason
+        for candidate in review.candidates:
+            assert "rfq_id" in candidate
+            assert "score" in candidate
+            assert "reason" in candidate
+
+
+# ---------------------------------------------------------------------------
+# Email extraction helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmail:
+    def test_bare_email(self):
+        assert _extract_email("tom@acme.com") == "tom@acme.com"
+
+    def test_angle_bracket_format(self):
+        assert _extract_email("Tom Reynolds <tom@acme.com>") == "tom@acme.com"
+
+    def test_case_normalized(self):
+        assert _extract_email("TOM@ACME.COM") == "tom@acme.com"
+
+    def test_none_returns_none(self):
+        assert _extract_email(None) is None
+
+    def test_empty_returns_none(self):
+        assert _extract_email("") is None


### PR DESCRIPTION
## Summary
- Tiered matching: thread (deterministic) -> sender -> context scoring -> review queue
- Auto-attach >= 0.85 confidence, review queue below, new RFQ for no matches
- Sets routing_status for Inbox badges (FR-EI-5), review queue for ambiguous (FR-EI-4)
- 14 tests, 100/100 total pass

Closes #13

## Test plan
- [ ] `python -m pytest tests/test_message_matching.py -v` — 14/14 pass
- [ ] `python -m pytest tests/ -v` — 100/100 pass
- [ ] Verify thread matching is deterministic (0.97-0.99)
- [ ] Verify ambiguous matches go to review queue, not auto-attach
- [ ] Verify closed RFQs excluded from matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)