### PR TITLE
#23 — Build confidence scoring and HITL escalation policy

### DIFF
--- a/backend/agents/extraction.py
+++ b/backend/agents/extraction.py
@@ -352,34 +352,37 @@ def _create_rfq_from_extraction(
 def _determine_initial_state(
     extracted: dict[str, Any],
     confidence: dict[str, float],
+    policy=None,
 ) -> RFQState:
     """
     Decide the initial RFQ state based on field completeness and confidence.
 
-    Required fields (per FR-AG-2 and the Agent Contracts doc):
-    - origin, destination, equipment_type, truck_count, commodity
+    Uses the escalation policy (#23) to check per-field thresholds. If no
+    policy is provided, uses the default (0.90 for all fields).
 
-    If any required field is null or has confidence below the threshold (0.90),
-    the RFQ starts in needs_clarification. Otherwise, it's ready_to_quote.
-
-    The 0.90 threshold is configurable per workflow (#23) — for now it's
-    hardcoded as the default per REQUIREMENTS.md FR-AG-2.
+    Required fields (per FR-AG-2): origin, destination, equipment_type,
+    truck_count, commodity. If any is null or below threshold -> needs_clarification.
     """
-    CONFIDENCE_THRESHOLD = 0.90
-    REQUIRED_FIELDS = ["origin", "destination", "equipment_type", "truck_count", "commodity"]
+    from backend.services.escalation_policy import (
+        EscalationPolicy,
+        REQUIRED_FIELDS,
+    )
+
+    if policy is None:
+        policy = EscalationPolicy()
 
     for field_name in REQUIRED_FIELDS:
-        # Check if the field value is missing
+        threshold = policy.get_threshold(field_name)
+
         if extracted.get(field_name) is None:
             logger.info("Field '%s' is null — RFQ needs clarification", field_name)
             return RFQState.NEEDS_CLARIFICATION
 
-        # Check if confidence is below threshold (FR-AG-2, FR-AG-3)
         field_confidence = confidence.get(field_name, 0.0)
-        if field_confidence < CONFIDENCE_THRESHOLD:
+        if field_confidence < threshold:
             logger.info(
                 "Field '%s' confidence %.2f < %.2f — RFQ needs clarification",
-                field_name, field_confidence, CONFIDENCE_THRESHOLD,
+                field_name, field_confidence, threshold,
             )
             return RFQState.NEEDS_CLARIFICATION
 
@@ -399,9 +402,11 @@ def _log_audit_event(
     email" in the timeline, not "extraction_completed" or "agent_call_success".
     Technical details are in the event_data JSONB for drill-down.
     """
+    from backend.services.escalation_policy import DEFAULT_THRESHOLD
+
     confidence = extracted.get("confidence", {})
     low_confidence_fields = [
-        k for k, v in confidence.items() if v < 0.90
+        k for k, v in confidence.items() if v < DEFAULT_THRESHOLD
     ]
 
     # Build a human-readable description (C3 — plain English)

--- a/backend/agents/validation.py
+++ b/backend/agents/validation.py
@@ -75,7 +75,7 @@ RECOMMENDED_FIELDS = {
     "delivery_date": "requested delivery date",
 }
 
-CONFIDENCE_THRESHOLD = 0.90
+from backend.services.escalation_policy import DEFAULT_THRESHOLD as CONFIDENCE_THRESHOLD
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/escalation_policy.py
+++ b/backend/services/escalation_policy.py
@@ -1,0 +1,237 @@
+"""
+backend/services/escalation_policy.py — Confidence scoring and HITL escalation policy.
+
+This service decides whether an RFQ needs human review based on per-field
+confidence scores from the extraction agent. It replaces the hardcoded 0.90
+threshold in extraction.py and validation.py with a configurable policy
+that can vary per workflow.
+
+How it works:
+    1. Load the escalation policy for the workflow (from workflows.config JSONB)
+    2. Evaluate each field's confidence score against the policy thresholds
+    3. If any required field is below threshold, flag for HITL review
+    4. Create a human-readable review card explaining what's uncertain and why
+
+The policy is stored in the workflow's config JSONB under the key
+"escalation_policy". Example:
+    {
+        "escalation_policy": {
+            "default_threshold": 0.90,
+            "field_thresholds": {
+                "destination": 0.85,
+                "commodity": 0.80
+            }
+        }
+    }
+
+If no policy is configured, the default (0.90 for all fields) is used.
+This matches the existing behavior before this issue was implemented.
+
+Called by:
+    - backend/agents/extraction.py — to determine initial RFQ state
+    - backend/agents/validation.py — to decide which fields need follow-up
+
+Cross-cutting constraints:
+    C3 — Escalation reasons use plain English ("destination is unclear")
+    FR-AG-2 — Every extracted field has a confidence score (0.0-1.0)
+    FR-AG-3 — Low-confidence fields flag the RFQ into Needs Review
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import AuditEvent, RFQ, Workflow
+
+logger = logging.getLogger("golteris.services.escalation_policy")
+
+# Default threshold when no policy is configured — matches FR-AG-2
+DEFAULT_THRESHOLD = 0.90
+
+# Required fields that trigger escalation when below threshold.
+# These are the fields a broker MUST have to send a quote to carriers.
+REQUIRED_FIELDS = ["origin", "destination", "equipment_type", "truck_count", "commodity"]
+
+# Human-readable labels for each field — used in review cards (C3)
+FIELD_LABELS = {
+    "origin": "pickup location",
+    "destination": "delivery location",
+    "equipment_type": "truck type",
+    "truck_count": "number of trucks",
+    "commodity": "what's being shipped",
+    "weight_lbs": "load weight",
+}
+
+
+@dataclass
+class EscalationPolicy:
+    """
+    Configuration for when to escalate an RFQ for human review.
+
+    Attributes:
+        default_threshold: The confidence threshold for all fields (0.0-1.0).
+            Fields with confidence below this trigger escalation.
+        field_thresholds: Per-field overrides. If a field has an entry here,
+            its threshold is used instead of default_threshold. Useful for
+            relaxing thresholds on commonly ambiguous fields (e.g., destination
+            in markets where city names repeat across states).
+    """
+    default_threshold: float = DEFAULT_THRESHOLD
+    field_thresholds: dict[str, float] = field(default_factory=dict)
+
+    def get_threshold(self, field_name: str) -> float:
+        """Get the effective threshold for a specific field."""
+        return self.field_thresholds.get(field_name, self.default_threshold)
+
+
+@dataclass
+class EscalationResult:
+    """
+    The outcome of evaluating an RFQ against the escalation policy.
+
+    Attributes:
+        needs_review: True if any field failed its threshold.
+        missing_fields: Fields that are null (not extracted at all).
+        low_confidence_fields: Fields below threshold with their scores.
+        reasons: Human-readable list of why escalation was triggered (C3).
+    """
+    needs_review: bool = False
+    missing_fields: list[tuple[str, str]] = field(default_factory=list)  # (field_name, label)
+    low_confidence_fields: list[tuple[str, str, float, float]] = field(default_factory=list)  # (field_name, label, score, threshold)
+    reasons: list[str] = field(default_factory=list)
+
+
+def get_policy_for_workflow(db: Session, workflow_id: Optional[int] = None) -> EscalationPolicy:
+    """
+    Load the escalation policy from a workflow's config.
+
+    If no workflow_id is provided or the workflow has no policy configured,
+    returns the default policy (0.90 for all fields).
+
+    Args:
+        db: SQLAlchemy session.
+        workflow_id: The workflow to load policy for (optional).
+
+    Returns:
+        EscalationPolicy with the configured or default thresholds.
+    """
+    if workflow_id is None:
+        return EscalationPolicy()
+
+    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+    if not workflow:
+        return EscalationPolicy()
+
+    config = workflow.config or {}
+    policy_config = config.get("escalation_policy", {})
+
+    return EscalationPolicy(
+        default_threshold=policy_config.get("default_threshold", DEFAULT_THRESHOLD),
+        field_thresholds=policy_config.get("field_thresholds", {}),
+    )
+
+
+def evaluate_rfq(
+    rfq: RFQ,
+    policy: Optional[EscalationPolicy] = None,
+) -> EscalationResult:
+    """
+    Evaluate an RFQ's confidence scores against the escalation policy.
+
+    Checks each required field for:
+    1. Missing values (null) — always triggers escalation
+    2. Low confidence — below the policy threshold for that field
+
+    Args:
+        rfq: The RFQ to evaluate.
+        policy: The escalation policy to apply. If None, uses the default.
+
+    Returns:
+        EscalationResult with the decision and human-readable reasons.
+    """
+    if policy is None:
+        policy = EscalationPolicy()
+
+    confidence = rfq.confidence_scores or {}
+    result = EscalationResult()
+
+    for field_name in REQUIRED_FIELDS:
+        label = FIELD_LABELS.get(field_name, field_name)
+        value = getattr(rfq, field_name, None)
+        threshold = policy.get_threshold(field_name)
+
+        if value is None:
+            # Field is missing entirely
+            result.missing_fields.append((field_name, label))
+            result.reasons.append(f"{label.capitalize()} is missing")
+            result.needs_review = True
+        else:
+            score = confidence.get(field_name, 1.0)
+            if score < threshold:
+                # Field exists but confidence is too low
+                result.low_confidence_fields.append((field_name, label, score, threshold))
+                # C3: plain English reason, not "confidence 0.45 < threshold 0.90"
+                result.reasons.append(
+                    f"{label.capitalize()} is unclear — \"{value}\" "
+                    f"(confidence {score:.0%}, needs {threshold:.0%})"
+                )
+                result.needs_review = True
+
+    return result
+
+
+def create_review_card(
+    db: Session,
+    rfq_id: int,
+    escalation: EscalationResult,
+) -> Optional[AuditEvent]:
+    """
+    Create a human-readable review card for an escalated RFQ.
+
+    The review card appears in the RFQ detail timeline and the Needs Review
+    queue. It explains in plain English what's uncertain and why the RFQ
+    was flagged for human review (C3, FR-AG-3).
+
+    Args:
+        db: SQLAlchemy session.
+        rfq_id: The RFQ that was escalated.
+        escalation: The escalation result with reasons.
+
+    Returns:
+        The created AuditEvent, or None if no escalation was needed.
+    """
+    if not escalation.needs_review:
+        return None
+
+    # Build human-readable description (C3)
+    if len(escalation.reasons) == 1:
+        description = f"Flagged for review — {escalation.reasons[0].lower()}"
+    else:
+        reason_list = "; ".join(r.lower() for r in escalation.reasons)
+        description = f"Flagged for review — {reason_list}"
+
+    event = AuditEvent(
+        rfq_id=rfq_id,
+        event_type="escalated_for_review",
+        actor="escalation_policy",
+        description=description,
+        event_data={
+            "missing_fields": [f for f, _ in escalation.missing_fields],
+            "low_confidence_fields": [
+                {"field": f, "score": s, "threshold": t}
+                for f, _, s, t in escalation.low_confidence_fields
+            ],
+            "reasons": escalation.reasons,
+        },
+    )
+    db.add(event)
+    db.commit()
+
+    logger.info(
+        "RFQ %d escalated: %d reasons — %s",
+        rfq_id, len(escalation.reasons), "; ".join(escalation.reasons),
+    )
+
+    return event

--- a/tests/test_escalation_policy.py
+++ b/tests/test_escalation_policy.py
@@ -1,0 +1,268 @@
+"""
+tests/test_escalation_policy.py — Tests for confidence scoring and HITL escalation (#23).
+
+Verifies the three acceptance criteria:
+    1. Low-confidence fields flag the whole RFQ
+    2. Threshold configurable per workflow
+    3. Escalation reason is human-readable in the review card
+"""
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.db.models import AuditEvent, Base, RFQ, RFQState, Workflow
+from backend.services.escalation_policy import (
+    DEFAULT_THRESHOLD,
+    EscalationPolicy,
+    create_review_card,
+    evaluate_rfq,
+    get_policy_for_workflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_compatible():
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _create_rfq(db, confidence_scores=None, **kwargs) -> RFQ:
+    defaults = {
+        "customer_name": "Test",
+        "customer_email": "test@example.com",
+        "origin": "Dallas, TX",
+        "destination": "Atlanta, GA",
+        "equipment_type": "Flatbed",
+        "truck_count": 1,
+        "commodity": "Steel coils",
+        "state": RFQState.NEEDS_CLARIFICATION,
+        "confidence_scores": confidence_scores,
+    }
+    defaults.update(kwargs)
+    rfq = RFQ(**defaults)
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+# ---------------------------------------------------------------------------
+# EscalationPolicy tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationPolicy:
+    def test_default_threshold(self):
+        policy = EscalationPolicy()
+        assert policy.default_threshold == 0.90
+        assert policy.get_threshold("origin") == 0.90
+        assert policy.get_threshold("destination") == 0.90
+
+    def test_per_field_override(self):
+        policy = EscalationPolicy(
+            default_threshold=0.90,
+            field_thresholds={"destination": 0.80, "commodity": 0.75},
+        )
+        assert policy.get_threshold("origin") == 0.90  # Uses default
+        assert policy.get_threshold("destination") == 0.80  # Uses override
+        assert policy.get_threshold("commodity") == 0.75  # Uses override
+
+    def test_custom_default_threshold(self):
+        policy = EscalationPolicy(default_threshold=0.85)
+        assert policy.get_threshold("origin") == 0.85
+
+
+# ---------------------------------------------------------------------------
+# Policy loading from workflow config
+# ---------------------------------------------------------------------------
+
+
+class TestGetPolicyForWorkflow:
+    def test_no_workflow_returns_default(self, db):
+        policy = get_policy_for_workflow(db, workflow_id=None)
+        assert policy.default_threshold == DEFAULT_THRESHOLD
+
+    def test_workflow_without_policy_returns_default(self, db):
+        wf = Workflow(name="Basic", enabled=True, config={})
+        db.add(wf)
+        db.commit()
+
+        policy = get_policy_for_workflow(db, wf.id)
+        assert policy.default_threshold == DEFAULT_THRESHOLD
+
+    def test_workflow_with_custom_policy(self, db):
+        wf = Workflow(name="Custom", enabled=True, config={
+            "escalation_policy": {
+                "default_threshold": 0.85,
+                "field_thresholds": {"destination": 0.80},
+            },
+        })
+        db.add(wf)
+        db.commit()
+
+        policy = get_policy_for_workflow(db, wf.id)
+        assert policy.default_threshold == 0.85
+        assert policy.get_threshold("destination") == 0.80
+        assert policy.get_threshold("origin") == 0.85  # Falls back to custom default
+
+    def test_nonexistent_workflow_returns_default(self, db):
+        policy = get_policy_for_workflow(db, workflow_id=99999)
+        assert policy.default_threshold == DEFAULT_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# RFQ evaluation tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateRfq:
+    """Acceptance criterion: low-confidence fields flag the whole RFQ."""
+
+    def test_high_confidence_no_escalation(self, db):
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.98, "destination": 0.98, "equipment_type": 0.99,
+            "truck_count": 0.99, "commodity": 0.97, "weight_lbs": 0.98,
+        })
+        result = evaluate_rfq(rfq)
+        assert result.needs_review is False
+        assert len(result.reasons) == 0
+
+    def test_low_confidence_triggers_escalation(self, db):
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.95, "destination": 0.45,  # Ambiguous Springfield
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.95, "weight_lbs": 0.94,
+        })
+        result = evaluate_rfq(rfq)
+        assert result.needs_review is True
+        low_fields = [f for f, _, _, _ in result.low_confidence_fields]
+        assert "destination" in low_fields
+
+    def test_missing_field_triggers_escalation(self, db):
+        rfq = _create_rfq(db, commodity=None, confidence_scores={
+            "origin": 0.95, "destination": 0.95, "equipment_type": 0.92,
+            "truck_count": 0.99, "commodity": 0.0, "weight_lbs": 0.0,
+        })
+        result = evaluate_rfq(rfq)
+        assert result.needs_review is True
+        missing = [f for f, _ in result.missing_fields]
+        assert "commodity" in missing
+
+    def test_custom_threshold_changes_outcome(self, db):
+        """With a lower threshold, a borderline field should pass."""
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.95, "destination": 0.87,  # Would fail at 0.90
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.95, "weight_lbs": 0.94,
+        })
+
+        # Default policy (0.90) — destination fails
+        result_strict = evaluate_rfq(rfq, EscalationPolicy(default_threshold=0.90))
+        assert result_strict.needs_review is True
+
+        # Relaxed policy (0.85) — destination passes
+        result_relaxed = evaluate_rfq(rfq, EscalationPolicy(default_threshold=0.85))
+        assert result_relaxed.needs_review is False
+
+    def test_per_field_threshold_override(self, db):
+        """Per-field threshold should override the default for that field only."""
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.95, "destination": 0.87,
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.95, "weight_lbs": 0.94,
+        })
+
+        policy = EscalationPolicy(
+            default_threshold=0.90,
+            field_thresholds={"destination": 0.85},  # Relax just destination
+        )
+        result = evaluate_rfq(rfq, policy)
+        assert result.needs_review is False  # 0.87 >= 0.85
+
+    def test_no_confidence_scores_defaults_high(self, db):
+        """RFQ with no confidence_scores should default to 1.0 (no escalation)."""
+        rfq = _create_rfq(db, confidence_scores=None)
+        result = evaluate_rfq(rfq)
+        assert result.needs_review is False
+
+
+# ---------------------------------------------------------------------------
+# Review card tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReviewCard:
+    """Acceptance criterion: escalation reason is human-readable."""
+
+    def test_creates_audit_event_with_plain_english(self, db):
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.95, "destination": 0.45,
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.95, "weight_lbs": 0.94,
+        })
+        escalation = evaluate_rfq(rfq)
+        event = create_review_card(db, rfq.id, escalation)
+
+        assert event is not None
+        assert event.event_type == "escalated_for_review"
+        assert event.actor == "escalation_policy"
+        # C3: plain English, not jargon
+        assert "flagged for review" in event.description.lower()
+        assert "delivery location" in event.description.lower()
+        assert "unclear" in event.description.lower()
+
+    def test_no_review_card_when_not_escalated(self, db):
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.98, "destination": 0.98, "equipment_type": 0.99,
+            "truck_count": 0.99, "commodity": 0.97, "weight_lbs": 0.98,
+        })
+        escalation = evaluate_rfq(rfq)
+        event = create_review_card(db, rfq.id, escalation)
+        assert event is None
+
+    def test_multiple_reasons_in_card(self, db):
+        rfq = _create_rfq(db, commodity=None, confidence_scores={
+            "origin": 0.95, "destination": 0.45,
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.0, "weight_lbs": 0.0,
+        })
+        escalation = evaluate_rfq(rfq)
+        event = create_review_card(db, rfq.id, escalation)
+
+        assert event is not None
+        assert len(escalation.reasons) >= 2
+        # Both reasons should be in the event data
+        assert len(event.event_data["reasons"]) >= 2
+
+    def test_event_data_has_structured_details(self, db):
+        rfq = _create_rfq(db, confidence_scores={
+            "origin": 0.95, "destination": 0.45,
+            "equipment_type": 0.97, "truck_count": 0.99,
+            "commodity": 0.95, "weight_lbs": 0.94,
+        })
+        escalation = evaluate_rfq(rfq)
+        event = create_review_card(db, rfq.id, escalation)
+
+        # Structured data for the UI to render the review card
+        assert "low_confidence_fields" in event.event_data
+        assert event.event_data["low_confidence_fields"][0]["field"] == "destination"
+        assert event.event_data["low_confidence_fields"][0]["score"] == 0.45


### PR DESCRIPTION
## Summary
- Configurable escalation policy with default + per-field threshold overrides
- Policy loaded from workflow.config JSONB (or defaults to 0.90)
- evaluate_rfq() checks required fields, create_review_card() logs plain-English audit events
- Refactored extraction.py + validation.py to use policy service (no behavior change with defaults)
- 17 new tests, 133/133 total pass

Closes #23

## Test plan
- [ ] `python -m pytest tests/test_escalation_policy.py -v` — 17/17 pass
- [ ] `python -m pytest tests/ -v` — 133/133 pass
- [ ] Verify default behavior unchanged (0.90 threshold)
- [ ] Verify per-field override works (e.g., destination at 0.85)
- [ ] Verify review card description is plain English (C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)