### PR TITLE
Update docs for Microsoft Graph email ingestion

### DIFF
--- a/PROJECT-PLAN.md
+++ b/PROJECT-PLAN.md
@@ -60,7 +60,7 @@ Build the minimum agent pipeline that turns one email into one structured RFQ in
 
 ### Deliverables
 
-- [ ] **Mailbox poller** — a Python function that pulls messages from a connected inbox on a cron (or for dev, from a seeded folder of sample emails). Supports any email provider via the abstraction layer (IMAP, Gmail, Outlook). Writes to `messages` table.
+- [ ] **Mailbox poller** — a Python function that pulls messages from a connected inbox on a cron (or for dev, from a seeded folder of sample emails). Supports any email provider via the abstraction layer (Microsoft Graph for Outlook/Microsoft 365, IMAP for Gmail/Yahoo, seed files for demo). Provider auto-detection: Graph > IMAP > seed files. Writes to `messages` table.
 - [ ] **Extraction agent** — Python function that reads a message, calls the LLM (via provider abstraction layer) with a structured tool-use schema, and writes extracted fields into `rfqs`. Logs the run to `agent_runs`.
 - [ ] **Validation agent** — checks required fields, sets `state` to `needs_clarification` or `ready_to_quote`, drafts a follow-up if missing data.
 - [ ] **Orchestrator loop** — a simple worker script that polls the database for RFQs in each state and dispatches the next agent.


### PR DESCRIPTION
## Summary
- PROJECT-PLAN.md: Updated Phase 1 mailbox poller to list Microsoft Graph as primary provider with auto-detection priority (Graph > IMAP > seed files)
- Environment-Setup-Runbook.md (local wiki): Added all MS_GRAPH_*, IMAP_*, SEED_EMAIL_DIR env vars with Entra setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)