### PR TITLE
#79 — Wire agent pipeline chain

### DIFF
--- a/backend/agents/extraction.py
+++ b/backend/agents/extraction.py
@@ -254,6 +254,20 @@ def extract_rfq(
         # Finish the run — rolls up cost and tokens from the LLM call
         finish_run(db, run.id)
 
+        # Chain to the next agent based on the RFQ state.
+        # All chaining goes through the job queue — agents never call
+        # each other directly. The worker picks up and dispatches.
+        from backend.worker import enqueue_job
+
+        if rfq.state == RFQState.NEEDS_CLARIFICATION:
+            # Missing or low-confidence fields — draft a follow-up email
+            enqueue_job(db, "validation", {"rfq_id": rfq.id}, rfq_id=rfq.id)
+            logger.info("RFQ %d needs clarification — validation job enqueued", rfq.id)
+        elif rfq.state == RFQState.READY_TO_QUOTE:
+            # All fields present and confident — generate quote sheet
+            enqueue_job(db, "quote_sheet", {"rfq_id": rfq.id}, rfq_id=rfq.id)
+            logger.info("RFQ %d ready to quote — quote sheet job enqueued", rfq.id)
+
         logger.info(
             "Extraction complete: message=%d -> rfq=%d origin=%s destination=%s confidence=%s",
             message_id, rfq.id, rfq.origin, rfq.destination,

--- a/backend/services/message_matching.py
+++ b/backend/services/message_matching.py
@@ -147,16 +147,22 @@ def match_message_to_rfq(db: Session, message_id: int) -> MatchResult:
         _send_to_review_queue(db, message, result)
         return result
 
-    # No candidates at all — this is likely a new RFQ
+    # No candidates at all — this is a new RFQ.
+    # Enqueue extraction so the pipeline automatically creates a structured
+    # RFQ from the email content. The chain continues from extraction:
+    #   extraction → validation (if needs_clarification) or quote_sheet (if ready)
+    from backend.worker import enqueue_job
+
     result = MatchResult(
         method="no_match",
-        reason="No matching RFQs found — likely a new quote request",
+        reason="No matching RFQs found — new quote request, extraction enqueued",
         routing_status=MessageRoutingStatus.NEW_RFQ_CREATED,
     )
     message.routing_status = result.routing_status
     db.commit()
 
-    logger.info("Message %d: no match — flagged as new RFQ", message_id)
+    enqueue_job(db, "extraction", {"message_id": message.id})
+    logger.info("Message %d: no match — new RFQ, extraction job enqueued", message_id)
     return result
 
 


### PR DESCRIPTION
## Summary
- Matching enqueues extraction when no RFQ match (new email)
- Extraction enqueues validation (needs_clarification) or quote_sheet (ready_to_quote)
- All via job queue — agents never call each other directly
- 2 files changed, 146/146 tests pass

Closes #79

## Test plan
- [ ] `python -m pytest tests/ -v` — 146/146 pass
- [ ] Verify matching.py enqueues extraction on no_match
- [ ] Verify extraction.py enqueues validation or quote_sheet based on state

🤖 Generated with [Claude Code](https://claude.com/claude-code)