### PR TITLE
#28 — Build inbox view with message routing

### DIFF
--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -171,6 +171,44 @@ def get_rfq_detail(
     }
 
 
+@router.get("/api/messages")
+def get_messages(
+    limit: int = Query(50, ge=1, le=200, description="Page size"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    routing_status: Optional[str] = Query(None, description="Filter by routing status"),
+    search: Optional[str] = Query(None, description="Search sender or subject"),
+    db: Session = Depends(get_db),
+):
+    """
+    List messages sorted by most recently received, with optional filters.
+
+    Used by the Inbox view (#28) to show every inbound message and how
+    Golteris routed it. Each message includes a routing badge and a link
+    to the attached RFQ (if any).
+    """
+    from backend.services.dashboard import list_messages
+    messages, total = list_messages(
+        db, limit=limit, offset=offset,
+        routing_status=routing_status, search=search,
+    )
+    return {
+        "messages": [_serialize_inbox_message(m) for m in messages],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/api/messages/counts")
+def get_message_counts(db: Session = Depends(get_db)):
+    """
+    Return message counts grouped by routing_status, for filter pill badges (#28).
+    """
+    from backend.services.dashboard import count_messages_by_routing
+    counts = count_messages_by_routing(db)
+    return {"counts": counts}
+
+
 @router.get("/api/approvals")
 def get_approvals(
     status: Optional[str] = Query("pending_approval", description="Filter by status"),
@@ -350,4 +388,38 @@ def _serialize_bid(bid: CarrierBid) -> dict:
         "availability": bid.availability,
         "notes": bid.notes,
         "received_at": bid.received_at.isoformat() if bid.received_at else None,
+    }
+
+
+def _serialize_inbox_message(msg: Message) -> dict:
+    """
+    Convert a Message to a JSON dict for the Inbox view (#28).
+
+    Includes routing_status badge and attached RFQ context (customer name)
+    so the broker can see at a glance how each message was handled.
+    """
+    rfq = msg.rfq
+    # Plain-English routing labels (C3)
+    routing_labels = {
+        "attached": "Attached to RFQ",
+        "new_rfq": "New RFQ created",
+        "needs_review": "Needs review",
+        "ignored": "Ignored",
+    }
+    routing_value = msg.routing_status.value if msg.routing_status else None
+    return {
+        "id": msg.id,
+        "rfq_id": msg.rfq_id,
+        "direction": msg.direction.value if msg.direction else None,
+        "sender": msg.sender,
+        "subject": msg.subject,
+        "body": msg.body,
+        "routing_status": routing_value,
+        "routing_label": routing_labels.get(routing_value, routing_value),
+        "received_at": msg.received_at.isoformat() if msg.received_at else None,
+        "rfq": {
+            "id": rfq.id,
+            "customer_name": rfq.customer_name,
+            "state_label": _state_label(rfq.state) if rfq.state else None,
+        } if rfq else None,
     }

--- a/backend/services/dashboard.py
+++ b/backend/services/dashboard.py
@@ -33,6 +33,8 @@ from backend.db.models import (
     ApprovalStatus,
     AuditEvent,
     CarrierBid,
+    Message,
+    MessageRoutingStatus,
     RFQ,
     RFQState,
     ReviewQueue,
@@ -184,6 +186,73 @@ def count_rfqs_by_state(db: Session) -> dict[str, int]:
         .all()
     )
     return {state.value: count for state, count in rows}
+
+
+def list_messages(
+    db: Session,
+    limit: int = 50,
+    offset: int = 0,
+    routing_status: Optional[str] = None,
+    search: Optional[str] = None,
+) -> tuple[list[Message], int]:
+    """
+    Return messages sorted by most recently received, with optional filters.
+
+    Used by the Inbox view (#28) to show every inbound message and how
+    Golteris routed it (attached, new_rfq, needs_review, ignored).
+
+    Args:
+        db: Database session
+        limit: Max rows to return
+        offset: Pagination offset
+        routing_status: Filter by routing status (e.g., "attached", "needs_review")
+        search: Search sender or subject (case-insensitive)
+
+    Returns:
+        Tuple of (message_list, total_count)
+    """
+    base_query = db.query(Message)
+
+    if routing_status:
+        try:
+            status_enum = MessageRoutingStatus(routing_status)
+            base_query = base_query.filter(Message.routing_status == status_enum)
+        except ValueError:
+            pass
+
+    if search:
+        search_term = f"%{search}%"
+        base_query = base_query.filter(
+            (Message.sender.ilike(search_term))
+            | (Message.subject.ilike(search_term))
+        )
+
+    total = base_query.count()
+    messages = (
+        base_query
+        .options(joinedload(Message.rfq))
+        .order_by(Message.received_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return messages, total
+
+
+def count_messages_by_routing(db: Session) -> dict[str, int]:
+    """
+    Return message counts grouped by routing_status, for filter pill badges.
+
+    Used by the Inbox view (#28) to show how many messages are in each
+    routing category.
+    """
+    rows = (
+        db.query(Message.routing_status, func.count(Message.id))
+        .filter(Message.routing_status.isnot(None))
+        .group_by(Message.routing_status)
+        .all()
+    )
+    return {status.value: count for status, count in rows}
 
 
 def list_pending_approvals(

--- a/frontend/src/hooks/use-messages.ts
+++ b/frontend/src/hooks/use-messages.ts
@@ -1,0 +1,66 @@
+/**
+ * hooks/use-messages.ts — React Query hooks for the Inbox view (#28).
+ *
+ * Provides:
+ * - useMessageList: paginated messages with routing filter and search
+ * - useMessageCounts: routing status counts for filter pill badges
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+export interface InboxMessage {
+  id: number
+  rfq_id: number | null
+  direction: "inbound" | "outbound" | null
+  sender: string
+  subject: string | null
+  body: string
+  routing_status: string | null
+  routing_label: string | null
+  received_at: string | null
+  rfq: {
+    id: number
+    customer_name: string | null
+    state_label: string | null
+  } | null
+}
+
+interface MessageListResponse {
+  messages: InboxMessage[]
+  total: number
+  limit: number
+  offset: number
+}
+
+interface MessageListParams {
+  limit?: number
+  offset?: number
+  routingStatus?: string | null
+  search?: string
+}
+
+export function useMessageList({
+  limit = 50,
+  offset = 0,
+  routingStatus = null,
+  search = "",
+}: MessageListParams) {
+  const params = new URLSearchParams()
+  params.set("limit", limit.toString())
+  params.set("offset", offset.toString())
+  if (routingStatus) params.set("routing_status", routingStatus)
+  if (search) params.set("search", search)
+
+  return useQuery({
+    queryKey: ["messages", "list", { limit, offset, routingStatus, search }],
+    queryFn: () => api.get<MessageListResponse>(`/api/messages?${params.toString()}`),
+  })
+}
+
+export function useMessageCounts() {
+  return useQuery({
+    queryKey: ["messages", "counts"],
+    queryFn: () => api.get<{ counts: Record<string, number> }>("/api/messages/counts"),
+  })
+}

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -1,13 +1,248 @@
 /**
- * pages/InboxPage.tsx — Placeholder for the Inbox view.
- * Will be implemented in a future issue.
+ * pages/InboxPage.tsx — Inbox view showing all messages with routing badges (#28).
+ *
+ * Shows every inbound message and how Golteris routed it:
+ * - Attached to an existing RFQ
+ * - Created a new RFQ
+ * - Sent to the review queue (ambiguous match)
+ * - Ignored (filtered out)
+ *
+ * The broker uses this to verify that message routing is trustworthy.
+ * Clicking a row opens the attached RFQ's detail drawer.
+ *
+ * Cross-cutting constraints:
+ *   C3 — Routing labels use plain English ("Attached to RFQ" not "attached")
  */
 
+import { useState, useMemo } from "react"
+import { Search, Inbox } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { RfqDetailDrawer } from "@/components/dashboard/RfqDetailDrawer"
+import { useMessageList, useMessageCounts } from "@/hooks/use-messages"
+import { formatRelativeTime, cn } from "@/lib/utils"
+
+/** Routing filter options with labels and badge colors. */
+const ROUTING_FILTERS = [
+  { value: null, label: "All" },
+  { value: "attached", label: "Attached", color: "bg-blue-100 text-blue-800" },
+  { value: "new_rfq", label: "New RFQ", color: "bg-green-100 text-green-800" },
+  { value: "needs_review", label: "Needs Review", color: "bg-amber-100 text-amber-800" },
+  { value: "ignored", label: "Ignored", color: "bg-gray-100 text-gray-600" },
+] as const
+
+/** Badge colors per routing status. */
+const routingColors: Record<string, string> = {
+  attached: "bg-blue-100 text-blue-800",
+  new_rfq: "bg-green-100 text-green-800",
+  needs_review: "bg-amber-100 text-amber-800",
+  ignored: "bg-gray-100 text-gray-600",
+}
+
+const PAGE_SIZE = 50
+
 export function InboxPage() {
+  const [routingFilter, setRoutingFilter] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+  const [selectedRfqId, setSelectedRfqId] = useState<number | null>(null)
+
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+  useMemo(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  const handleRoutingFilter = (status: string | null) => {
+    setRoutingFilter(status)
+    setPage(0)
+  }
+
+  const messages = useMessageList({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    routingStatus: routingFilter,
+    search: debouncedSearch,
+  })
+  const counts = useMessageCounts()
+
+  const totalPages = Math.ceil((messages.data?.total ?? 0) / PAGE_SIZE)
+
   return (
-    <div className="p-6">
-      <h2 className="text-xl font-semibold text-[#0E2841] mb-2">Inbox</h2>
-      <p className="text-muted-foreground">Email inbox view coming soon.</p>
+    <div className="p-4 lg:p-6 max-w-7xl space-y-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <h2 className="text-xl font-semibold text-[#0E2841] flex items-center gap-2">
+          <Inbox className="h-5 w-5" />
+          Inbox
+          {messages.data && (
+            <span className="text-sm font-normal text-muted-foreground">
+              {messages.data.total} messages
+            </span>
+          )}
+        </h2>
+
+        {/* Search */}
+        <div className="relative w-full sm:w-72">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search sender, subject..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 text-sm border rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-[#0F9ED5]/30 focus:border-[#0F9ED5]"
+          />
+        </div>
+      </div>
+
+      {/* Routing filter pills */}
+      <div className="flex flex-wrap gap-2">
+        {ROUTING_FILTERS.map((filter) => {
+          const count = filter.value
+            ? counts.data?.counts[filter.value] ?? 0
+            : Object.values(counts.data?.counts ?? {}).reduce((a, b) => a + b, 0)
+          const isActive = routingFilter === filter.value
+
+          return (
+            <button
+              key={filter.value ?? "all"}
+              onClick={() => handleRoutingFilter(filter.value)}
+              className={cn(
+                "inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors border",
+                isActive
+                  ? "bg-[#0E2841] text-white border-[#0E2841]"
+                  : "bg-white text-muted-foreground border-border hover:bg-muted/50"
+              )}
+            >
+              {filter.label}
+              <span
+                className={cn(
+                  "text-[10px] font-mono",
+                  isActive ? "text-white/70" : "text-muted-foreground/60"
+                )}
+              >
+                {count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Table */}
+      {messages.isLoading ? (
+        <div className="space-y-2">
+          {[...Array(8)].map((_, i) => (
+            <div key={i} className="h-12 bg-white rounded animate-pulse shadow-sm" />
+          ))}
+        </div>
+      ) : (messages.data?.messages.length ?? 0) === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm py-12 text-center">
+          <p className="text-muted-foreground">
+            {search ? `No messages matching "${search}"` : "No messages yet"}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-sm overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-xs">Sender</TableHead>
+                <TableHead className="text-xs hidden md:table-cell">Subject</TableHead>
+                <TableHead className="text-xs">Routing</TableHead>
+                <TableHead className="text-xs hidden lg:table-cell">RFQ</TableHead>
+                <TableHead className="text-xs text-right">Received</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {messages.data?.messages.map((msg) => (
+                <TableRow
+                  key={msg.id}
+                  className={cn(
+                    "hover:bg-muted/50",
+                    msg.rfq_id && "cursor-pointer"
+                  )}
+                  onClick={() => msg.rfq_id && setSelectedRfqId(msg.rfq_id)}
+                >
+                  <TableCell className="py-3">
+                    <p className="text-sm font-medium truncate max-w-[200px]">
+                      {msg.sender}
+                    </p>
+                  </TableCell>
+                  <TableCell className="py-3 hidden md:table-cell">
+                    <p className="text-sm truncate max-w-[300px]">
+                      {msg.subject ?? "—"}
+                    </p>
+                  </TableCell>
+                  <TableCell className="py-3">
+                    {msg.routing_status ? (
+                      <Badge
+                        variant="secondary"
+                        className={`text-xs ${routingColors[msg.routing_status] ?? ""}`}
+                      >
+                        {msg.routing_label}
+                      </Badge>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="py-3 hidden lg:table-cell">
+                    {msg.rfq ? (
+                      <span className="text-xs text-[#0F9ED5]">
+                        #{msg.rfq.id} {msg.rfq.customer_name}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground text-right py-3">
+                    {msg.received_at ? formatRelativeTime(msg.received_at) : "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Showing {page * PAGE_SIZE + 1}–
+            {Math.min((page + 1) * PAGE_SIZE, messages.data?.total ?? 0)} of{" "}
+            {messages.data?.total}
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1 text-xs border rounded-md disabled:opacity-40 hover:bg-muted/50"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-3 py-1 text-xs border rounded-md disabled:opacity-40 hover:bg-muted/50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* RFQ detail drawer — opens when clicking a message with an attached RFQ */}
+      <RfqDetailDrawer
+        rfqId={selectedRfqId}
+        onClose={() => setSelectedRfqId(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #28 — Inbox view showing all messages with routing badges, filters, search, and RFQ drawer link.

### Backend
- **GET `/api/messages`** with `?routing_status=`, `?search=`, pagination
- **GET `/api/messages/counts`** — routing status counts for filter pills

### Frontend
- Routing filter pills (Attached, New RFQ, Needs Review, Ignored) with live counts
- Search input with 300ms debounce (sender/subject)
- Full table: Sender, Subject, Routing Badge, RFQ link, Received time
- Row click opens attached RFQ detail drawer
- Pagination (50 per page)

## Test plan
- [x] `npm run build` — zero TS errors
- [ ] Navigate to /inbox → message list with routing badges
- [ ] Click filter pills → table filters by routing status
- [ ] Search by sender → results filter
- [ ] Click a row with an attached RFQ → detail drawer opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)