### PR TITLE
#30 — Build history view with stat strip

### DIFF
--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -171,6 +171,38 @@ def get_rfq_detail(
     }
 
 
+@router.get("/api/history")
+def get_history(
+    limit: int = Query(50, ge=1, le=200, description="Page size"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    outcome: Optional[str] = Query(None, description="Filter by outcome: won, lost, cancelled"),
+    period: Optional[str] = Query(None, description="Time filter: today, week, month"),
+    db: Session = Depends(get_db),
+):
+    """
+    Return closed RFQs with stats for the History view (#30).
+
+    The stat strip shows aggregated performance metrics. The table shows
+    individual closed RFQs with outcome, quoted amount, and cycle time.
+    Historical entries are immutable per FR-DM-5.
+    """
+    from backend.services.dashboard import get_history_stats, list_closed_rfqs
+
+    stats = get_history_stats(db)
+    rfqs, total = list_closed_rfqs(
+        db, limit=limit, offset=offset,
+        outcome_filter=outcome, period=period,
+    )
+
+    return {
+        "stats": stats,
+        "rfqs": [_serialize_history_rfq(r) for r in rfqs],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
 @router.get("/api/messages")
 def get_messages(
     limit: int = Query(50, ge=1, le=200, description="Page size"),
@@ -388,6 +420,35 @@ def _serialize_bid(bid: CarrierBid) -> dict:
         "availability": bid.availability,
         "notes": bid.notes,
         "received_at": bid.received_at.isoformat() if bid.received_at else None,
+    }
+
+
+def _serialize_history_rfq(rfq: RFQ) -> dict:
+    """
+    Convert a closed RFQ to a JSON dict for the History table (#30).
+
+    Includes outcome, quoted amount, and cycle time (hours from creation
+    to close) so the broker can see performance at a glance.
+    """
+    cycle_hours = None
+    if rfq.closed_at and rfq.created_at:
+        delta = (rfq.closed_at - rfq.created_at).total_seconds() / 3600
+        cycle_hours = round(delta, 1)
+
+    return {
+        "id": rfq.id,
+        "customer_name": rfq.customer_name,
+        "customer_company": rfq.customer_company,
+        "origin": rfq.origin,
+        "destination": rfq.destination,
+        "equipment_type": rfq.equipment_type,
+        "state": rfq.state.value if rfq.state else None,
+        "state_label": _state_label(rfq.state) if rfq.state else None,
+        "outcome": rfq.outcome,
+        "quoted_amount": float(rfq.quoted_amount) if rfq.quoted_amount else None,
+        "cycle_hours": cycle_hours,
+        "closed_at": rfq.closed_at.isoformat() if rfq.closed_at else None,
+        "created_at": rfq.created_at.isoformat() if rfq.created_at else None,
     }
 
 

--- a/backend/services/dashboard.py
+++ b/backend/services/dashboard.py
@@ -20,7 +20,7 @@ Called by:
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from sqlalchemy import func
@@ -253,6 +253,128 @@ def count_messages_by_routing(db: Session) -> dict[str, int]:
         .all()
     )
     return {status.value: count for status, count in rows}
+
+
+def get_history_stats(db: Session) -> dict:
+    """
+    Return the four stat strip values for the History view (#30).
+
+    Stats:
+        completed_today (int): RFQs that reached a terminal state today
+        avg_time_to_quote_hours (float): Average hours from RFQ creation to quote_sent
+        approvals_this_week (int): Approvals resolved in the last 7 days
+        time_saved_hours (float): Total agent run duration this week, in hours
+
+    C5 — time_saved uses real agent_run duration_ms (defensible metric).
+    """
+    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=today_start.weekday())
+
+    # Completed today — RFQs closed today
+    completed_today = (
+        db.query(func.count(RFQ.id))
+        .filter(
+            RFQ.state.in_(TERMINAL_STATES),
+            RFQ.closed_at >= today_start,
+        )
+        .scalar()
+    ) or 0
+
+    # Avg time to quote — average hours from creation to closed_at for quote_sent/won/lost
+    from sqlalchemy import extract
+    avg_query = (
+        db.query(
+            func.avg(
+                func.extract("epoch", RFQ.closed_at) - func.extract("epoch", RFQ.created_at)
+            )
+        )
+        .filter(
+            RFQ.closed_at.isnot(None),
+            RFQ.state.in_([RFQState.WON, RFQState.LOST, RFQState.QUOTE_SENT]),
+        )
+        .scalar()
+    )
+    avg_time_to_quote_hours = round((avg_query or 0) / 3600, 1)
+
+    # Approvals this week
+    approvals_this_week = (
+        db.query(func.count(Approval.id))
+        .filter(
+            Approval.resolved_at >= week_start,
+            Approval.status.in_([ApprovalStatus.APPROVED, ApprovalStatus.REJECTED]),
+        )
+        .scalar()
+    ) or 0
+
+    # Time saved this week (hours) — sum of completed agent run durations
+    total_duration_ms = (
+        db.query(func.coalesce(func.sum(AgentRun.duration_ms), 0))
+        .filter(
+            AgentRun.status == AgentRunStatus.COMPLETED,
+            AgentRun.finished_at >= week_start,
+        )
+        .scalar()
+    ) or 0
+    time_saved_hours = round(total_duration_ms / 3600000, 1)
+
+    return {
+        "completed_today": completed_today,
+        "avg_time_to_quote_hours": avg_time_to_quote_hours,
+        "approvals_this_week": approvals_this_week,
+        "time_saved_hours": time_saved_hours,
+    }
+
+
+def list_closed_rfqs(
+    db: Session,
+    limit: int = 50,
+    offset: int = 0,
+    outcome_filter: Optional[str] = None,
+    period: Optional[str] = None,
+) -> tuple[list[RFQ], int]:
+    """
+    Return closed RFQs (won/lost/cancelled) for the History view (#30).
+
+    Args:
+        db: Database session
+        limit: Max rows
+        offset: Pagination offset
+        outcome_filter: Filter by outcome state (won/lost/cancelled)
+        period: Time range filter (today/week/month)
+
+    Returns:
+        Tuple of (rfq_list, total_count)
+    """
+    base_query = db.query(RFQ).filter(RFQ.state.in_(TERMINAL_STATES))
+
+    if outcome_filter:
+        try:
+            state_enum = RFQState(outcome_filter)
+            base_query = base_query.filter(RFQ.state == state_enum)
+        except ValueError:
+            pass
+
+    if period:
+        now = datetime.utcnow()
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        if period == "today":
+            base_query = base_query.filter(RFQ.closed_at >= today_start)
+        elif period == "week":
+            week_start = today_start - timedelta(days=today_start.weekday())
+            base_query = base_query.filter(RFQ.closed_at >= week_start)
+        elif period == "month":
+            month_start = today_start.replace(day=1)
+            base_query = base_query.filter(RFQ.closed_at >= month_start)
+
+    total = base_query.count()
+    rfqs = (
+        base_query
+        .order_by(RFQ.closed_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return rfqs, total
 
 
 def list_pending_approvals(

--- a/frontend/src/hooks/use-history.ts
+++ b/frontend/src/hooks/use-history.ts
@@ -1,0 +1,64 @@
+/**
+ * hooks/use-history.ts — React Query hook for the History view (#30).
+ *
+ * Fetches GET /api/history with stats and closed RFQs.
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+export interface HistoryRfq {
+  id: number
+  customer_name: string | null
+  customer_company: string | null
+  origin: string | null
+  destination: string | null
+  equipment_type: string | null
+  state: string
+  state_label: string
+  outcome: string | null
+  quoted_amount: number | null
+  cycle_hours: number | null
+  closed_at: string | null
+  created_at: string
+}
+
+export interface HistoryStats {
+  completed_today: number
+  avg_time_to_quote_hours: number
+  approvals_this_week: number
+  time_saved_hours: number
+}
+
+interface HistoryResponse {
+  stats: HistoryStats
+  rfqs: HistoryRfq[]
+  total: number
+  limit: number
+  offset: number
+}
+
+interface HistoryParams {
+  limit?: number
+  offset?: number
+  outcome?: string | null
+  period?: string | null
+}
+
+export function useHistory({
+  limit = 50,
+  offset = 0,
+  outcome = null,
+  period = null,
+}: HistoryParams) {
+  const params = new URLSearchParams()
+  params.set("limit", limit.toString())
+  params.set("offset", offset.toString())
+  if (outcome) params.set("outcome", outcome)
+  if (period) params.set("period", period)
+
+  return useQuery({
+    queryKey: ["history", { limit, offset, outcome, period }],
+    queryFn: () => api.get<HistoryResponse>(`/api/history?${params.toString()}`),
+  })
+}

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,13 +1,258 @@
 /**
- * pages/HistoryPage.tsx — Placeholder for the History view.
- * Will be implemented in a future issue.
+ * pages/HistoryPage.tsx — History view with stat strip and closed RFQs (#30).
+ *
+ * Shows completed RFQs (won/lost/cancelled) with performance stats that
+ * justify the product's value. The stat strip shows aggregated metrics;
+ * the table shows individual closed RFQs with outcome and cycle time.
+ *
+ * Historical entries are immutable per FR-DM-5.
+ *
+ * Cross-cutting constraints:
+ *   C3 — Outcome labels use plain English
+ *   C5 — Time Saved uses defensible agent run durations
  */
 
+import { useState } from "react"
+import { Clock, CheckCircle, ThumbsUp, TrendingUp } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { KpiCard } from "@/components/dashboard/KpiCard"
+import { RfqDetailDrawer } from "@/components/dashboard/RfqDetailDrawer"
+import { useHistory } from "@/hooks/use-history"
+import { formatRelativeTime, cn } from "@/lib/utils"
+
+/** Outcome filter options. */
+const OUTCOME_FILTERS = [
+  { value: null, label: "All" },
+  { value: "won", label: "Won", color: "bg-green-200 text-green-900" },
+  { value: "lost", label: "Lost", color: "bg-gray-100 text-gray-600" },
+  { value: "cancelled", label: "Cancelled", color: "bg-gray-100 text-gray-600" },
+] as const
+
+/** Time range filters. */
+const PERIOD_FILTERS = [
+  { value: null, label: "All Time" },
+  { value: "today", label: "Today" },
+  { value: "week", label: "This Week" },
+  { value: "month", label: "This Month" },
+] as const
+
+const outcomeColors: Record<string, string> = {
+  won: "bg-green-200 text-green-900",
+  lost: "bg-gray-100 text-gray-600",
+  cancelled: "bg-gray-100 text-gray-600",
+}
+
+const PAGE_SIZE = 50
+
 export function HistoryPage() {
+  const [outcomeFilter, setOutcomeFilter] = useState<string | null>(null)
+  const [periodFilter, setPeriodFilter] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+  const [selectedRfqId, setSelectedRfqId] = useState<number | null>(null)
+
+  const history = useHistory({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    outcome: outcomeFilter,
+    period: periodFilter,
+  })
+
+  const stats = history.data?.stats
+  const totalPages = Math.ceil((history.data?.total ?? 0) / PAGE_SIZE)
+
   return (
-    <div className="p-6">
-      <h2 className="text-xl font-semibold text-[#0E2841] mb-2">History</h2>
-      <p className="text-muted-foreground">Completed RFQ history coming soon.</p>
+    <div className="p-4 lg:p-6 max-w-7xl space-y-6">
+      {/* Header */}
+      <h2 className="text-xl font-semibold text-[#0E2841]">History</h2>
+
+      {/* Stat strip — 4 cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats ? (
+          <>
+            <KpiCard
+              icon={CheckCircle}
+              value={stats.completed_today}
+              label="Completed Today"
+              iconBg="bg-green-50"
+              iconColor="text-green-600"
+            />
+            <KpiCard
+              icon={Clock}
+              value={stats.avg_time_to_quote_hours > 0 ? `${stats.avg_time_to_quote_hours}h` : "—"}
+              label="Avg Time to Quote"
+              iconBg="bg-[#E8F4FC]"
+              iconColor="text-[#0F9ED5]"
+            />
+            <KpiCard
+              icon={ThumbsUp}
+              value={stats.approvals_this_week}
+              label="Approvals This Week"
+              iconBg="bg-purple-50"
+              iconColor="text-purple-600"
+            />
+            <KpiCard
+              icon={TrendingUp}
+              value={stats.time_saved_hours > 0 ? `${stats.time_saved_hours}h` : "0h"}
+              label="Time Saved This Week"
+              iconBg="bg-amber-50"
+              iconColor="text-amber-600"
+            />
+          </>
+        ) : (
+          [...Array(4)].map((_, i) => (
+            <div key={i} className="h-[88px] rounded-lg bg-white animate-pulse shadow-sm" />
+          ))
+        )}
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2 items-center">
+        {/* Outcome filters */}
+        {OUTCOME_FILTERS.map((filter) => (
+          <button
+            key={filter.value ?? "all-outcome"}
+            onClick={() => { setOutcomeFilter(filter.value); setPage(0) }}
+            className={cn(
+              "px-3 py-1 rounded-full text-xs font-medium transition-colors border",
+              outcomeFilter === filter.value
+                ? "bg-[#0E2841] text-white border-[#0E2841]"
+                : "bg-white text-muted-foreground border-border hover:bg-muted/50"
+            )}
+          >
+            {filter.label}
+          </button>
+        ))}
+
+        <span className="text-muted-foreground text-xs mx-1">|</span>
+
+        {/* Period filters */}
+        {PERIOD_FILTERS.map((filter) => (
+          <button
+            key={filter.value ?? "all-period"}
+            onClick={() => { setPeriodFilter(filter.value); setPage(0) }}
+            className={cn(
+              "px-3 py-1 rounded-full text-xs font-medium transition-colors border",
+              periodFilter === filter.value
+                ? "bg-[#0F9ED5] text-white border-[#0F9ED5]"
+                : "bg-white text-muted-foreground border-border hover:bg-muted/50"
+            )}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Table */}
+      {history.isLoading ? (
+        <div className="space-y-2">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-12 bg-white rounded animate-pulse shadow-sm" />
+          ))}
+        </div>
+      ) : (history.data?.rfqs.length ?? 0) === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm py-12 text-center">
+          <p className="text-muted-foreground">No completed RFQs yet</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-sm overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-xs w-16">#</TableHead>
+                <TableHead className="text-xs">Shipper</TableHead>
+                <TableHead className="text-xs hidden md:table-cell">Route</TableHead>
+                <TableHead className="text-xs">Outcome</TableHead>
+                <TableHead className="text-xs hidden lg:table-cell text-right">Quoted</TableHead>
+                <TableHead className="text-xs hidden sm:table-cell text-right">Cycle</TableHead>
+                <TableHead className="text-xs text-right">Closed</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {history.data?.rfqs.map((rfq) => (
+                <TableRow
+                  key={rfq.id}
+                  className="cursor-pointer hover:bg-muted/50"
+                  onClick={() => setSelectedRfqId(rfq.id)}
+                >
+                  <TableCell className="text-xs font-mono text-muted-foreground py-3">
+                    {rfq.id}
+                  </TableCell>
+                  <TableCell className="py-3">
+                    <p className="text-sm font-medium">{rfq.customer_name ?? "Unknown"}</p>
+                    {rfq.customer_company && (
+                      <p className="text-xs text-muted-foreground">{rfq.customer_company}</p>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-sm py-3 hidden md:table-cell">
+                    {rfq.origin && rfq.destination
+                      ? `${rfq.origin} → ${rfq.destination}`
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="py-3">
+                    <Badge
+                      variant="secondary"
+                      className={`text-xs ${outcomeColors[rfq.state] ?? ""}`}
+                    >
+                      {rfq.state_label}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-right py-3 hidden lg:table-cell">
+                    {rfq.quoted_amount
+                      ? `$${rfq.quoted_amount.toLocaleString()}`
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground text-right py-3 hidden sm:table-cell">
+                    {rfq.cycle_hours != null ? `${rfq.cycle_hours}h` : "—"}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground text-right py-3">
+                    {rfq.closed_at ? formatRelativeTime(rfq.closed_at) : "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Showing {page * PAGE_SIZE + 1}–
+            {Math.min((page + 1) * PAGE_SIZE, history.data?.total ?? 0)} of{" "}
+            {history.data?.total}
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1 text-xs border rounded-md disabled:opacity-40 hover:bg-muted/50"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-3 py-1 text-xs border rounded-md disabled:opacity-40 hover:bg-muted/50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      <RfqDetailDrawer
+        rfqId={selectedRfqId}
+        onClose={() => setSelectedRfqId(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #30 — History view with performance stat strip, outcome/period filters, and closed RFQ table.

### Backend
- **GET `/api/history`** — Stats + closed RFQs with `?outcome=` and `?period=` filters
- Stats: completed_today, avg_time_to_quote_hours, approvals_this_week, time_saved_hours (C5 defensible)

### Frontend
- 4-card stat strip reusing KpiCard component
- Outcome pills (Won/Lost/Cancelled) + period pills (Today/Week/Month)
- Table with outcome badge, quoted amount, cycle time, closed date
- Row click opens detail drawer

## Test plan
- [x] `npm run build` — zero TS errors
- [ ] Navigate to /history → stat strip + closed RFQs table
- [ ] Filter by Won/Lost → table updates
- [ ] Filter by This Week → narrows results

🤖 Generated with [Claude Code](https://claude.com/claude-code)