### PR TITLE
#25 — Implement outbound email sending with approval gate

### DIFF
--- a/backend/api/approvals.py
+++ b/backend/api/approvals.py
@@ -123,7 +123,7 @@ def approve(
     If the approval is already resolved (approved/rejected/skipped), returns 400.
     If the approval doesn't exist, returns 404.
 
-    On success, creates an audit event and returns the updated approval.
+    On success, creates an audit event and enqueues the outbound send job (#25).
     """
     result = approve_approval(
         db,
@@ -133,6 +133,17 @@ def approve(
     )
     if result is None:
         return _not_found_or_resolved(db, approval_id)
+
+    # Enqueue the outbound email send job (#25).
+    # The worker will pick this up, verify C2 one more time, and send via
+    # the configured email provider (Graph, IMAP, or file).
+    from backend.worker import enqueue_job
+    enqueue_job(
+        db,
+        job_type="send_outbound_email",
+        payload={"approval_id": result.id},
+        rfq_id=result.rfq_id,
+    )
 
     return _action_response(result)
 

--- a/backend/email/file_provider.py
+++ b/backend/email/file_provider.py
@@ -92,6 +92,44 @@ class FileMailboxProvider(MailboxProvider):
 
         return messages
 
+    def send_message(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        reply_to_message_id: str | None = None,
+    ) -> dict:
+        """
+        Log outbound email to a file instead of actually sending (#25).
+
+        Used in dev/demo mode when no real email provider is configured.
+        Writes to a .sent.json file in the seed directory so the broker
+        can verify what would have been sent.
+        """
+        import json
+        from datetime import datetime
+
+        sent_file = os.path.join(self.seed_dir, ".sent.json")
+        try:
+            with open(sent_file, "r") as f:
+                sent_log = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            sent_log = []
+
+        sent_log.append({
+            "to": to,
+            "subject": subject,
+            "body": body,
+            "reply_to": reply_to_message_id,
+            "sent_at": datetime.utcnow().isoformat(),
+        })
+
+        with open(sent_file, "w") as f:
+            json.dump(sent_log, f, indent=2)
+
+        logger.info("Email logged to file (dev mode) to=%s subject=%s", to, subject)
+        return {"success": True, "message_id": None, "error": None}
+
     def get_provider_name(self) -> str:
         return "file"
 

--- a/backend/email/graph_provider.py
+++ b/backend/email/graph_provider.py
@@ -162,6 +162,83 @@ class GraphMailboxProvider(MailboxProvider):
 
         return messages
 
+    def send_message(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        reply_to_message_id: str | None = None,
+    ) -> dict:
+        """
+        Send an email via Microsoft Graph API's /sendMail endpoint (#25).
+
+        Uses the same OAuth2 client credentials as fetch. Requires
+        Mail.Send application permission in the Entra app registration.
+
+        C2 CONSTRAINT: Only called by email_send service after approval check.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body (plain text)
+            reply_to_message_id: For threading, the original message's internet message ID
+
+        Returns:
+            Dict with success, message_id, and error fields.
+        """
+        if not self.client_id or not self.user_email:
+            return {"success": False, "message_id": None, "error": "Graph API not configured"}
+
+        token = self._get_access_token()
+        if not token:
+            return {"success": False, "message_id": None, "error": "Failed to get Graph access token"}
+
+        try:
+            # Build the Graph API sendMail payload
+            mail_payload: dict = {
+                "message": {
+                    "subject": subject,
+                    "body": {
+                        "contentType": "Text",
+                        "content": body,
+                    },
+                    "toRecipients": [
+                        {"emailAddress": {"address": to}}
+                    ],
+                },
+                "saveToSentItems": True,
+            }
+
+            # If replying to a thread, set the in-reply-to header for proper threading
+            if reply_to_message_id:
+                mail_payload["message"]["internetMessageHeaders"] = [
+                    {"name": "In-Reply-To", "value": reply_to_message_id},
+                ]
+
+            url = f"{GRAPH_BASE_URL}/users/{self.user_email}/sendMail"
+            resp = requests.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                json=mail_payload,
+                timeout=30,
+            )
+
+            if resp.status_code == 202:
+                # 202 Accepted — email queued for delivery by Graph
+                logger.info("Email sent via Graph to %s: %s", to, subject)
+                return {"success": True, "message_id": None, "error": None}
+            else:
+                error_detail = resp.text[:500]
+                logger.error("Graph sendMail failed (%d): %s", resp.status_code, error_detail)
+                return {"success": False, "message_id": None, "error": f"Graph API {resp.status_code}: {error_detail}"}
+
+        except requests.RequestException as e:
+            logger.error("Graph sendMail request error: %s", e)
+            return {"success": False, "message_id": None, "error": str(e)}
+
     def get_provider_name(self) -> str:
         return "graph"
 

--- a/backend/email/imap_provider.py
+++ b/backend/email/imap_provider.py
@@ -131,6 +131,47 @@ class IMAPMailboxProvider(MailboxProvider):
 
         return messages
 
+    def send_message(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        reply_to_message_id: str | None = None,
+    ) -> dict:
+        """
+        Send an email via SMTP using the same credentials as IMAP (#25).
+
+        Derives the SMTP host from the IMAP host (most providers use the same
+        hostname with different ports). Uses STARTTLS on port 587.
+
+        C2 CONSTRAINT: Only called by email_send service after approval check.
+        """
+        import smtplib
+        from email.mime.text import MIMEText
+
+        # Derive SMTP host from IMAP host (imap.gmail.com → smtp.gmail.com, etc.)
+        smtp_host = self.host.replace("imap.", "smtp.")
+
+        try:
+            msg = MIMEText(body)
+            msg["Subject"] = subject
+            msg["From"] = self.user
+            msg["To"] = to
+            if reply_to_message_id:
+                msg["In-Reply-To"] = reply_to_message_id
+
+            with smtplib.SMTP(smtp_host, 587, timeout=30) as server:
+                server.starttls()
+                server.login(self.user, self.password)
+                server.sendmail(self.user, [to], msg.as_string())
+
+            logger.info("Email sent via SMTP to %s: %s", to, subject)
+            return {"success": True, "message_id": msg["Message-ID"], "error": None}
+
+        except smtplib.SMTPException as e:
+            logger.error("SMTP send failed: %s", e)
+            return {"success": False, "message_id": None, "error": str(e)}
+
     def get_provider_name(self) -> str:
         return "imap"
 

--- a/backend/email/provider.py
+++ b/backend/email/provider.py
@@ -56,6 +56,38 @@ class MailboxProvider(ABC):
         ...
 
     @abstractmethod
+    def send_message(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        reply_to_message_id: str | None = None,
+    ) -> dict:
+        """
+        Send an outbound email via this provider (#25).
+
+        C2 CONSTRAINT: This method must NEVER be called directly. It is only
+        called by the email_send service AFTER verifying approval.status == APPROVED.
+
+        Args:
+            to: Recipient email address.
+            subject: Email subject line.
+            body: Email body (plain text).
+            reply_to_message_id: If replying to a thread, the message-id header
+                of the original message (for proper threading).
+
+        Returns:
+            Dict with send result metadata:
+                - success (bool): Whether the send succeeded
+                - message_id (str|None): Provider's message ID for the sent email
+                - error (str|None): Error message if send failed
+
+        Raises:
+            NotImplementedError: If the provider doesn't support sending.
+        """
+        ...
+
+    @abstractmethod
     def get_provider_name(self) -> str:
         """Return a human-readable provider name (e.g., 'file', 'imap', 'gmail')."""
         ...

--- a/backend/services/email_send.py
+++ b/backend/services/email_send.py
@@ -1,0 +1,219 @@
+"""
+backend/services/email_send.py — Outbound email send service (#25).
+
+This is the C2 enforcement point for outbound communication. It verifies
+that an approval has status=APPROVED before sending any email. Nothing
+bypasses this check — not even in tests.
+
+Flow:
+    1. Worker dispatches a "send_outbound_email" job with {approval_id}
+    2. This service loads the approval, verifies status == APPROVED
+    3. Gets the email body (resolved_body if edited, otherwise draft_body)
+    4. Sends via the configured email provider (Graph, IMAP, or file)
+    5. Persists an outbound Message row for the RFQ thread
+    6. Creates an AuditEvent ("email_sent")
+    7. On failure: logs error, creates a review AuditEvent (FR-HI-6)
+
+Cross-cutting constraints:
+    C2 — No email sends without approved=true on the draft record
+    C4 — Every send/failure is audited with full traceability
+    FR-HI-1 — Drafts persist with pending_approval; only send after approved
+    FR-HI-6 — Failed sends create a review card, not silent disappearance
+
+Called by:
+    backend/worker.py via JOB_DISPATCH["send_outbound_email"]
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import (
+    Approval,
+    ApprovalStatus,
+    AuditEvent,
+    Message,
+    MessageDirection,
+)
+from backend.services.email_ingestion import get_provider_from_config
+
+logger = logging.getLogger("golteris.services.email_send")
+
+
+def send_approved_email(db: Session, approval_id: int) -> None:
+    """
+    Send an outbound email for an approved draft.
+
+    This is the ONLY function that sends email. It is called by the worker
+    when processing a "send_outbound_email" job.
+
+    C2 HARD GATE: If approval.status != APPROVED, this function refuses
+    to send and logs a warning. This is the final safety check — even if
+    a bug enqueues a send job for a non-approved draft, it will not send.
+
+    Args:
+        db: SQLAlchemy session
+        approval_id: ID of the approved Approval record
+
+    Side effects:
+        - Sends an email via the configured provider
+        - Creates an outbound Message row linked to the RFQ
+        - Creates an AuditEvent for traceability (C4)
+        - On failure: creates a failure AuditEvent (FR-HI-6)
+    """
+    # Load the approval
+    approval = db.query(Approval).filter(Approval.id == approval_id).first()
+    if not approval:
+        logger.error("Send job for approval %d: not found", approval_id)
+        return
+
+    # ===== C2 ENFORCEMENT — THE CRITICAL CHECK =====
+    # If the approval is not in APPROVED status, refuse to send.
+    # This is the absolute last line of defense. Even if a send job
+    # was enqueued by mistake, this check prevents unauthorized sends.
+    if approval.status != ApprovalStatus.APPROVED:
+        logger.warning(
+            "Send job for approval %d: status is %s, not APPROVED — refusing to send (C2)",
+            approval_id,
+            approval.status.value,
+        )
+        return
+
+    # Determine which body to send — edited version if broker edited, otherwise original
+    email_body = approval.resolved_body or approval.draft_body
+    email_subject = approval.draft_subject or "(no subject)"
+    email_to = approval.draft_recipient
+
+    if not email_to:
+        logger.error("Send job for approval %d: no recipient", approval_id)
+        _create_failure_event(
+            db, approval, "No recipient address on the draft"
+        )
+        return
+
+    # Find the original inbound message for threading (In-Reply-To header)
+    reply_to_message_id = None
+    if approval.rfq_id:
+        original = (
+            db.query(Message)
+            .filter(
+                Message.rfq_id == approval.rfq_id,
+                Message.direction == MessageDirection.INBOUND,
+            )
+            .order_by(Message.received_at.desc())
+            .first()
+        )
+        if original:
+            reply_to_message_id = original.message_id_header
+
+    # Send via the configured provider
+    provider = get_provider_from_config()
+    logger.info(
+        "Sending email via %s: to=%s subject=%s (approval=%d)",
+        provider.get_provider_name(), email_to, email_subject, approval_id,
+    )
+
+    result = provider.send_message(
+        to=email_to,
+        subject=email_subject,
+        body=email_body,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+    if result["success"]:
+        _handle_send_success(db, approval, email_to, email_subject, email_body, result)
+    else:
+        _handle_send_failure(db, approval, result["error"])
+
+
+def _handle_send_success(
+    db: Session,
+    approval: Approval,
+    to: str,
+    subject: str,
+    body: str,
+    result: dict,
+) -> None:
+    """
+    After a successful send: persist the outbound message and audit event.
+
+    Creates a Message row with direction=OUTBOUND so it appears in the
+    RFQ's message thread. Creates an AuditEvent so the broker sees
+    "Email sent to [recipient]" in the timeline.
+    """
+    # Persist the outbound message in the RFQ thread
+    outbound_msg = Message(
+        rfq_id=approval.rfq_id,
+        direction=MessageDirection.OUTBOUND,
+        sender="jillian@beltmann.com",  # The broker's sending identity
+        recipients=to,
+        subject=subject,
+        body=body,
+        received_at=datetime.now(timezone.utc),
+    )
+    db.add(outbound_msg)
+
+    # Audit event — the broker sees "Email sent" in the timeline (C4)
+    type_label = approval.approval_type.value.replace("_", " ")
+    event = AuditEvent(
+        rfq_id=approval.rfq_id,
+        event_type="email_sent",
+        actor="system",
+        description=f"Sent {type_label} to {to}",
+        event_data={
+            "approval_id": approval.id,
+            "approval_type": approval.approval_type.value,
+            "recipient": to,
+            "subject": subject,
+            "provider_message_id": result.get("message_id"),
+        },
+    )
+    db.add(event)
+    db.commit()
+
+    logger.info("Email sent successfully for approval %d", approval.id)
+
+
+def _handle_send_failure(
+    db: Session,
+    approval: Approval,
+    error: str,
+) -> None:
+    """
+    After a failed send: create a review card so the failure is visible (FR-HI-6).
+
+    Failed sends do NOT silently disappear. The broker sees a failure event
+    in the timeline and can investigate or retry.
+    """
+    _create_failure_event(db, approval, error)
+    logger.error("Email send failed for approval %d: %s", approval.id, error)
+
+
+def _create_failure_event(
+    db: Session,
+    approval: Approval,
+    error: str,
+) -> None:
+    """
+    Create an audit event for a send failure (FR-HI-6).
+
+    The broker sees "Failed to send [type] to [recipient]" in the timeline
+    with the error details in event_data.
+    """
+    type_label = approval.approval_type.value.replace("_", " ")
+    recipient = approval.draft_recipient or "unknown"
+    event = AuditEvent(
+        rfq_id=approval.rfq_id,
+        event_type="email_send_failed",
+        actor="system",
+        description=f"Failed to send {type_label} to {recipient}: {error}",
+        event_data={
+            "approval_id": approval.id,
+            "approval_type": approval.approval_type.value,
+            "recipient": recipient,
+            "error": error,
+        },
+    )
+    db.add(event)
+    db.commit()

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -198,6 +198,8 @@ JOB_DISPATCH = {
     "validation": ("backend.agents.validation", "draft_followup", "rfq_id"),
     "quote_sheet": ("backend.agents.quote_sheet", "generate_quote_sheet", "rfq_id"),
     "matching": ("backend.services.message_matching", "match_message_to_rfq", "message_id"),
+    # Outbound email sending (#25) — only runs after C2 approval gate
+    "send_outbound_email": ("backend.services.email_send", "send_approved_email", "approval_id"),
 }
 
 

--- a/tests/test_email_send.py
+++ b/tests/test_email_send.py
@@ -1,0 +1,240 @@
+"""
+tests/test_email_send.py — Tests for outbound email sending (#25).
+
+Verifies the C2 enforcement gate and the send pipeline:
+    1. Only APPROVED drafts trigger a send
+    2. Non-approved drafts are refused
+    3. Successful sends create outbound Message + AuditEvent
+    4. Failed sends create a failure AuditEvent (FR-HI-6)
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import JSON, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+
+from backend.db.models import (
+    Approval,
+    ApprovalStatus,
+    ApprovalType,
+    AuditEvent,
+    Base,
+    Message,
+    MessageDirection,
+    RFQ,
+    RFQState,
+)
+from backend.services.email_send import send_approved_email
+
+
+def _make_sqlite_compatible():
+    """Swap JSONB -> JSON so SQLite can create the tables."""
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture
+def db():
+    """Fresh in-memory SQLite database for each test."""
+    _make_sqlite_compatible()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _make_rfq(db) -> RFQ:
+    rfq = RFQ(
+        customer_name="Test Shipper", customer_company="Test Co",
+        origin="Chicago, IL", destination="Dallas, TX",
+        state=RFQState.READY_TO_QUOTE,
+        created_at=datetime.utcnow(), updated_at=datetime.utcnow(),
+    )
+    db.add(rfq)
+    db.commit()
+    db.refresh(rfq)
+    return rfq
+
+
+def _make_approval(db, rfq_id, status=ApprovalStatus.APPROVED) -> Approval:
+    approval = Approval(
+        rfq_id=rfq_id,
+        approval_type=ApprovalType.CUSTOMER_REPLY,
+        draft_body="Hi, here is your quote.",
+        draft_subject="Re: Quote Request",
+        draft_recipient="shipper@example.com",
+        reason="Draft reply ready",
+        status=status,
+        resolved_by="broker" if status == ApprovalStatus.APPROVED else None,
+        resolved_at=datetime.utcnow() if status == ApprovalStatus.APPROVED else None,
+    )
+    db.add(approval)
+    db.commit()
+    db.refresh(approval)
+    return approval
+
+
+class TestC2Gate:
+    """C2 enforcement — no email sends without approved=true."""
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_approved_sends(self, mock_provider_fn, db):
+        """An APPROVED approval triggers a send."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": True, "message_id": "abc", "error": None}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id, ApprovalStatus.APPROVED)
+
+        send_approved_email(db, approval.id)
+
+        # Verify provider.send_message was called
+        mock_provider.send_message.assert_called_once()
+        call_kwargs = mock_provider.send_message.call_args
+        assert call_kwargs[1]["to"] == "shipper@example.com"
+        assert call_kwargs[1]["subject"] == "Re: Quote Request"
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_pending_does_not_send(self, mock_provider_fn, db):
+        """A PENDING_APPROVAL approval does NOT trigger a send (C2)."""
+        mock_provider = MagicMock()
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id, ApprovalStatus.PENDING_APPROVAL)
+
+        send_approved_email(db, approval.id)
+
+        # Provider should never be called
+        mock_provider.send_message.assert_not_called()
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_rejected_does_not_send(self, mock_provider_fn, db):
+        """A REJECTED approval does NOT trigger a send (C2)."""
+        mock_provider = MagicMock()
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id, ApprovalStatus.REJECTED)
+
+        send_approved_email(db, approval.id)
+
+        mock_provider.send_message.assert_not_called()
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_nonexistent_approval_no_crash(self, mock_provider_fn, db):
+        """Sending for a nonexistent approval ID doesn't crash."""
+        send_approved_email(db, 9999)
+        mock_provider_fn.return_value.send_message.assert_not_called()
+
+
+class TestSendSuccess:
+    """Successful sends persist outbound message and audit event."""
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_creates_outbound_message(self, mock_provider_fn, db):
+        """A successful send creates an OUTBOUND Message row."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": True, "message_id": None, "error": None}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id)
+
+        send_approved_email(db, approval.id)
+
+        outbound = db.query(Message).filter(
+            Message.rfq_id == rfq.id,
+            Message.direction == MessageDirection.OUTBOUND,
+        ).first()
+        assert outbound is not None
+        assert outbound.recipients == "shipper@example.com"
+        assert outbound.subject == "Re: Quote Request"
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_creates_email_sent_event(self, mock_provider_fn, db):
+        """A successful send creates an 'email_sent' audit event (C4)."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": True, "message_id": None, "error": None}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id)
+
+        send_approved_email(db, approval.id)
+
+        event = db.query(AuditEvent).filter(
+            AuditEvent.event_type == "email_sent"
+        ).first()
+        assert event is not None
+        assert "shipper@example.com" in event.description
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_uses_resolved_body_if_edited(self, mock_provider_fn, db):
+        """If the broker edited the draft, the edited body is sent."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": True, "message_id": None, "error": None}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id)
+        approval.resolved_body = "Edited version of the reply"
+        db.commit()
+
+        send_approved_email(db, approval.id)
+
+        call_kwargs = mock_provider.send_message.call_args
+        assert call_kwargs[1]["body"] == "Edited version of the reply"
+
+
+class TestSendFailure:
+    """Failed sends create review cards, not silent disappearance (FR-HI-6)."""
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_failure_creates_review_event(self, mock_provider_fn, db):
+        """A failed send creates an 'email_send_failed' audit event."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": False, "message_id": None, "error": "Auth failed"}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id)
+
+        send_approved_email(db, approval.id)
+
+        event = db.query(AuditEvent).filter(
+            AuditEvent.event_type == "email_send_failed"
+        ).first()
+        assert event is not None
+        assert "Auth failed" in event.description
+
+    @patch("backend.services.email_send.get_provider_from_config")
+    def test_failure_does_not_create_outbound_message(self, mock_provider_fn, db):
+        """A failed send does NOT persist an outbound message."""
+        mock_provider = MagicMock()
+        mock_provider.send_message.return_value = {"success": False, "message_id": None, "error": "Timeout"}
+        mock_provider.get_provider_name.return_value = "mock"
+        mock_provider_fn.return_value = mock_provider
+
+        rfq = _make_rfq(db)
+        approval = _make_approval(db, rfq.id)
+
+        send_approved_email(db, approval.id)
+
+        outbound = db.query(Message).filter(
+            Message.direction == MessageDirection.OUTBOUND,
+        ).first()
+        assert outbound is None


### PR DESCRIPTION
## Summary

Closes #25 — Wires the complete approve → send pipeline. No email leaves the system without C2 approval.

### Email Provider Send
- Abstract `send_message()` on all providers
- **Graph**: Microsoft Graph `/sendMail` API with OAuth2
- **IMAP**: SMTP send (derives host from IMAP config)
- **File**: Logs to `.sent.json` for dev/demo

### Send Service (`backend/services/email_send.py`)
- `send_approved_email(db, approval_id)` — **THE C2 gate**
- Hard refuses if `status != APPROVED` (defense in depth)
- Sends edited body if broker modified, otherwise original draft
- Persists outbound Message in RFQ thread
- Creates "email_sent" audit event (C4)
- Failed sends create "email_send_failed" review event (FR-HI-6)

### Pipeline Wiring
- Approve endpoint → enqueues `send_outbound_email` job
- Worker dispatch table → routes to `send_approved_email`
- C2 checked **twice**: at approval AND at send

### Tests (9 pass)
- C2 gate: approved sends, pending/rejected refuse, nonexistent no crash
- Success: outbound message created, audit event, edited body used
- Failure: failure event created, no outbound message (FR-HI-6)

## Test plan
- [x] `pytest tests/test_email_send.py -v` — 9 passed
- [x] `pytest tests/test_dashboard_api.py -v` — 24 passed (no regressions)
- [ ] Approve a draft in UI → job enqueued → email sent via Graph (needs live Graph creds)
- [ ] Verify outbound message appears in RFQ detail drawer Messages tab
- [ ] Verify "Email sent" event appears in activity feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)