### PR TITLE
#34 — Build carrier bid comparison and ranking

### DIFF
--- a/backend/api/carriers.py
+++ b/backend/api/carriers.py
@@ -84,6 +84,46 @@ def distribute_rfq(
     return result
 
 
+@router.get("/api/rfqs/{rfq_id}/bids")
+def get_ranked_bids(rfq_id: int, db: Session = Depends(get_db)):
+    """
+    Return ranked carrier bids for an RFQ (#34).
+
+    Bids are sorted by total landed cost with tags:
+    best_value, runner_up, outlier_high, outlier_low.
+    """
+    from backend.services.bid_ranking import rank_bids
+
+    rfq = db.query(RFQ).filter(RFQ.id == rfq_id).first()
+    if not rfq:
+        raise HTTPException(status_code=404, detail=f"RFQ {rfq_id} not found")
+
+    ranked = rank_bids(db, rfq_id)
+    return {
+        "rfq_id": rfq_id,
+        "bids": [
+            {
+                "id": rb.bid.id,
+                "rank": rb.rank,
+                "carrier_name": rb.bid.carrier_name,
+                "carrier_email": rb.bid.carrier_email,
+                "rate": float(rb.bid.rate) if rb.bid.rate else None,
+                "normalized_rate": rb.normalized_rate,
+                "currency": rb.bid.currency,
+                "rate_type": rb.bid.rate_type,
+                "terms": rb.bid.terms,
+                "availability": rb.bid.availability,
+                "notes": rb.bid.notes,
+                "tag": rb.tag,
+                "reason": rb.reason,
+                "received_at": rb.bid.received_at.isoformat() if rb.bid.received_at else None,
+            }
+            for rb in ranked
+        ],
+        "total": len(ranked),
+    }
+
+
 def _serialize_carrier(carrier: Carrier) -> dict:
     """Convert a Carrier to a JSON dict for the selection UI."""
     return {

--- a/backend/services/bid_ranking.py
+++ b/backend/services/bid_ranking.py
@@ -1,0 +1,154 @@
+"""
+backend/services/bid_ranking.py — Carrier bid comparison and ranking (#34).
+
+Takes all carrier bids for an RFQ, normalizes them to comparable total
+landed costs, ranks them, identifies the best value, and flags outliers.
+
+The broker sees the ranked list in the RFQ detail drawer with "Best Value",
+"Runner Up", and "Outlier" badges to speed up decision-making.
+
+Ranking logic:
+    1. Normalize all bids to total USD amount (handle rate_type variations)
+    2. Sort by normalized rate ascending (cheapest first)
+    3. Tag #1 as "Best Value", #2-3 as "Runner Up"
+    4. Flag bids >30% above median as "Outlier (high)"
+    5. Flag bids >30% below median as "Outlier (low)" — suspiciously cheap
+
+Called by:
+    backend/api/carriers.py GET /api/rfqs/{id}/bids
+"""
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from statistics import median
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import CarrierBid, RFQ
+
+logger = logging.getLogger("golteris.services.bid_ranking")
+
+# Outlier threshold — bids more than 30% above/below median are flagged
+OUTLIER_THRESHOLD = 0.30
+
+
+@dataclass
+class RankedBid:
+    """A carrier bid with its ranking metadata."""
+    bid: CarrierBid
+    rank: int
+    normalized_rate: float
+    tag: str  # "best_value", "runner_up", "outlier_high", "outlier_low", or ""
+    reason: str  # Human-readable explanation of the tag
+
+
+def rank_bids(db: Session, rfq_id: int) -> list[RankedBid]:
+    """
+    Rank all carrier bids for an RFQ by total landed cost.
+
+    Returns a list of RankedBid objects sorted cheapest-first, with
+    tags identifying best value, runner ups, and outliers.
+
+    Args:
+        db: SQLAlchemy session
+        rfq_id: The RFQ to rank bids for
+
+    Returns:
+        List of RankedBid objects, sorted by normalized_rate ascending.
+        Empty list if no bids exist.
+    """
+    bids = (
+        db.query(CarrierBid)
+        .filter(CarrierBid.rfq_id == rfq_id, CarrierBid.rate.isnot(None))
+        .order_by(CarrierBid.rate.asc())
+        .all()
+    )
+
+    if not bids:
+        return []
+
+    # Normalize rates to comparable USD totals
+    normalized = [(bid, _normalize_rate(bid)) for bid in bids]
+
+    # Sort by normalized rate
+    normalized.sort(key=lambda x: x[1])
+
+    # Calculate median for outlier detection
+    rates = [n for _, n in normalized]
+    med = median(rates) if rates else 0
+
+    # Build ranked list with tags
+    ranked = []
+    for i, (bid, norm_rate) in enumerate(normalized):
+        rank = i + 1
+        tag, reason = _compute_tag(rank, norm_rate, med, len(normalized))
+        ranked.append(RankedBid(
+            bid=bid,
+            rank=rank,
+            normalized_rate=norm_rate,
+            tag=tag,
+            reason=reason,
+        ))
+
+    return ranked
+
+
+def _normalize_rate(bid: CarrierBid) -> float:
+    """
+    Normalize a bid rate to a comparable total USD amount.
+
+    Handles different rate structures:
+    - all_in / flat: rate is the total → use as-is
+    - linehaul_plus_fsc: rate is base, assume ~15% FSC surcharge
+    - per_mile: would need distance data (not available yet, use as-is)
+
+    Returns the normalized rate as a float.
+    """
+    rate = float(bid.rate) if bid.rate else 0.0
+
+    if bid.rate_type == "linehaul_plus_fsc":
+        # Estimate FSC at ~15% of linehaul — this is a rough industry average
+        rate *= 1.15
+    # per_mile would need route distance — for now treat as-is
+    # all_in and flat are already total rates
+
+    return rate
+
+
+def _compute_tag(
+    rank: int,
+    rate: float,
+    median_rate: float,
+    total_bids: int,
+) -> tuple[str, str]:
+    """
+    Determine the display tag and reason for a ranked bid.
+
+    Returns:
+        Tuple of (tag, reason) where tag is one of:
+        "best_value", "runner_up", "outlier_high", "outlier_low", or ""
+    """
+    if median_rate == 0:
+        return ("", "")
+
+    deviation = (rate - median_rate) / median_rate
+
+    # Check for outliers first
+    if deviation > OUTLIER_THRESHOLD:
+        pct = abs(deviation) * 100
+        return ("outlier_high", f"{pct:.0f}% above median — verify terms")
+    if deviation < -OUTLIER_THRESHOLD and total_bids > 2:
+        pct = abs(deviation) * 100
+        return ("outlier_low", f"{pct:.0f}% below median — verify scope")
+
+    # Tags for top 3
+    if rank == 1:
+        if total_bids == 1:
+            return ("best_value", "Only bid received")
+        return ("best_value", "Lowest total landed cost")
+    if rank <= 3:
+        return ("runner_up", f"#{rank} by total cost")
+
+    return ("", "")

--- a/frontend/src/components/dashboard/RfqDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/RfqDetailDrawer.tsx
@@ -29,6 +29,7 @@ import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CarrierSelectModal } from "./CarrierSelectModal"
 import { useRfqDetail } from "@/hooks/use-rfq-detail"
+import { useRankedBids, type RankedBid } from "@/hooks/use-ranked-bids"
 import { formatRelativeTime } from "@/lib/utils"
 import type { RfqDetail, RfqMessage, ActivityEvent, CarrierBidItem } from "@/types/api"
 
@@ -54,6 +55,7 @@ interface RfqDetailDrawerProps {
 
 export function RfqDetailDrawer({ rfqId, onClose }: RfqDetailDrawerProps) {
   const { data, isLoading } = useRfqDetail(rfqId)
+  const rankedBids = useRankedBids(rfqId)
   const isOpen = rfqId !== null
   const [carrierModalRfqId, setCarrierModalRfqId] = useState<number | null>(null)
 
@@ -131,11 +133,11 @@ export function RfqDetailDrawer({ rfqId, onClose }: RfqDetailDrawerProps) {
               </TabsContent>
             </Tabs>
 
-            {/* Carrier bids (shown if any exist) */}
-            {data.carrier_bids.length > 0 && (
+            {/* Ranked carrier bids (#34) — shown if any bids exist */}
+            {(rankedBids.data?.total ?? 0) > 0 && (
               <div className="mt-6">
                 <Separator className="mb-4" />
-                <BidsSection bids={data.carrier_bids} />
+                <RankedBidsSection bids={rankedBids.data?.bids ?? []} />
               </div>
             )}
 
@@ -370,27 +372,53 @@ function TimelineSection({ events }: { events: ActivityEvent[] }) {
 }
 
 
-/** Carrier bids section — shown below tabs when bids exist. */
-function BidsSection({ bids }: { bids: CarrierBidItem[] }) {
+/** Ranked carrier bids section (#34) — shows bids with ranking tags. */
+function RankedBidsSection({ bids }: { bids: RankedBid[] }) {
+  const tagStyles: Record<string, string> = {
+    best_value: "bg-green-100 text-green-800",
+    runner_up: "bg-blue-100 text-blue-800",
+    outlier_high: "bg-red-100 text-red-800",
+    outlier_low: "bg-amber-100 text-amber-800",
+  }
+  const tagLabels: Record<string, string> = {
+    best_value: "Best Value",
+    runner_up: "Runner Up",
+    outlier_high: "Outlier (High)",
+    outlier_low: "Outlier (Low)",
+  }
+
   return (
     <div>
       <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-        Carrier Bids ({bids.length})
+        Carrier Bids — Ranked ({bids.length})
       </p>
       <div className="space-y-2">
         {bids.map((bid) => (
           <div
             key={bid.id}
-            className="flex items-center justify-between border rounded-lg p-3"
+            className={`flex items-center justify-between border rounded-lg p-3 ${
+              bid.tag === "best_value" ? "border-green-300 bg-green-50/50" : ""
+            }`}
           >
-            <div>
-              <p className="text-sm font-medium">{bid.carrier_name}</p>
-              {bid.terms && (
-                <p className="text-xs text-muted-foreground">{bid.terms}</p>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-mono text-muted-foreground">#{bid.rank}</span>
+                <p className="text-sm font-medium">{bid.carrier_name}</p>
+                {bid.tag && (
+                  <Badge variant="secondary" className={`text-[10px] ${tagStyles[bid.tag] ?? ""}`}>
+                    {tagLabels[bid.tag] ?? bid.tag}
+                  </Badge>
+                )}
+              </div>
+              {bid.reason && (
+                <p className="text-xs text-muted-foreground mt-0.5">{bid.reason}</p>
+              )}
+              {bid.availability && (
+                <p className="text-xs text-muted-foreground">{bid.availability}</p>
               )}
             </div>
-            <div className="text-right">
-              {bid.rate && (
+            <div className="text-right shrink-0 ml-4">
+              {bid.rate != null && (
                 <p className="text-sm font-bold text-[#0E2841]">
                   ${bid.rate.toLocaleString()}
                 </p>

--- a/frontend/src/hooks/use-ranked-bids.ts
+++ b/frontend/src/hooks/use-ranked-bids.ts
@@ -1,0 +1,37 @@
+/**
+ * hooks/use-ranked-bids.ts — React Query hook for ranked carrier bids (#34).
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+export interface RankedBid {
+  id: number
+  rank: number
+  carrier_name: string
+  carrier_email: string | null
+  rate: number | null
+  normalized_rate: number
+  currency: string | null
+  rate_type: string | null
+  terms: string | null
+  availability: string | null
+  notes: string | null
+  tag: string
+  reason: string
+  received_at: string | null
+}
+
+interface RankedBidsResponse {
+  rfq_id: number
+  bids: RankedBid[]
+  total: number
+}
+
+export function useRankedBids(rfqId: number | null) {
+  return useQuery({
+    queryKey: ["rfq", "bids", rfqId],
+    queryFn: () => api.get<RankedBidsResponse>(`/api/rfqs/${rfqId}/bids`),
+    enabled: rfqId !== null,
+  })
+}


### PR DESCRIPTION
## Summary

Closes #34 — Bid ranking with Best Value/Runner Up/Outlier tags.

- **bid_ranking.py** — Normalize rates, rank by cost, flag outliers (>30% from median)
- **GET `/api/rfqs/{id}/bids`** — Ranked bids with tags and reasons
- **RFQ detail drawer** — Ranked bids section with green highlight on Best Value

## Test plan
- [x] `npm run build` — zero TS errors
- [ ] RFQ with multiple bids shows ranked list with tags
- [ ] Best Value bid highlighted, outliers flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)