### PR TITLE
#31 — Build settings page with workflow toggles and kill switch

### DIFF
--- a/backend/api/dev.py
+++ b/backend/api/dev.py
@@ -37,6 +37,7 @@ from backend.db.models import (
     RFQ,
     RFQState,
     ReviewQueue,
+    Workflow,
 )
 
 logger = logging.getLogger("golteris.api.dev")
@@ -73,7 +74,18 @@ def reseed_demo_data(db: Session = Depends(get_db)):
     db.query(Message).delete()
     db.query(RFQ).delete()
     db.query(Carrier).delete()
+    db.query(Workflow).delete()
     db.commit()
+
+    # --- Workflows (C1 enforcement) ---
+    workflows_data = [
+        ("Inbound Quote Processing", True),
+        ("Carrier Distribution", True),
+        ("Follow-up Automation", False),
+    ]
+    for wf_name, enabled in workflows_data:
+        db.add(Workflow(name=wf_name, enabled=enabled))
+    db.flush()
 
     # --- Carriers ---
     carriers_data = [
@@ -294,6 +306,7 @@ def reseed_demo_data(db: Session = Depends(get_db)):
         "seeded": {
             "rfqs": len(rfqs),
             "messages": len(messages_data),
+            "workflows": len(workflows_data),
             "carriers": len(carriers),
             "approvals": len(approvals_data),
             "carrier_bids": 3,

--- a/backend/api/workflows.py
+++ b/backend/api/workflows.py
@@ -1,0 +1,184 @@
+"""
+backend/api/workflows.py — FastAPI router for workflow management (#31).
+
+Provides the Settings page endpoints for toggling workflows on/off,
+the global kill switch, and viewing workflow status.
+
+Endpoints:
+    GET  /api/workflows           — List all workflows with enabled status
+    PUT  /api/workflows/{id}      — Toggle a workflow on/off
+    POST /api/workflows/kill      — Kill switch — disable ALL workflows
+    GET  /api/settings/status     — System status (cost caps, mailbox, worker)
+
+Cross-cutting constraints:
+    C1 — Workflow toggles are the enforcement point. When disabled, the worker
+         stops dispatching jobs for that workflow within 30 seconds.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.db.database import get_db
+from backend.db.models import AuditEvent, Workflow
+
+logger = logging.getLogger("golteris.api.workflows")
+
+router = APIRouter(tags=["settings"])
+
+
+@router.get("/api/workflows")
+def list_workflows(db: Session = Depends(get_db)):
+    """
+    List all workflows with their enabled status.
+
+    The Settings page renders a toggle switch for each workflow.
+    C1: when enabled=False, the worker stops processing jobs for that workflow.
+    """
+    workflows = db.query(Workflow).order_by(Workflow.name.asc()).all()
+    return {
+        "workflows": [
+            {
+                "id": w.id,
+                "name": w.name,
+                "enabled": w.enabled,
+                "updated_at": w.updated_at.isoformat() if w.updated_at else None,
+            }
+            for w in workflows
+        ],
+    }
+
+
+class ToggleRequest(BaseModel):
+    """Request body for toggling a workflow."""
+    enabled: bool
+
+
+@router.put("/api/workflows/{workflow_id}")
+def toggle_workflow(
+    workflow_id: int,
+    body: ToggleRequest,
+    db: Session = Depends(get_db),
+):
+    """
+    Toggle a workflow on or off (C1 enforcement point).
+
+    When disabled, the background worker will stop dispatching new jobs
+    for this workflow. Existing running jobs complete but no new ones start.
+    """
+    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+    if not workflow:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+
+    old_state = workflow.enabled
+    workflow.enabled = body.enabled
+    workflow.updated_at = datetime.now(timezone.utc)
+
+    # Audit the toggle (C1 visibility)
+    action = "enabled" if body.enabled else "disabled"
+    event = AuditEvent(
+        event_type=f"workflow_{action}",
+        actor="broker",
+        description=f"Workflow '{workflow.name}' {action}",
+        event_data={
+            "workflow_id": workflow.id,
+            "workflow_name": workflow.name,
+            "old_state": old_state,
+            "new_state": body.enabled,
+        },
+    )
+    db.add(event)
+    db.commit()
+
+    return {
+        "id": workflow.id,
+        "name": workflow.name,
+        "enabled": workflow.enabled,
+    }
+
+
+@router.post("/api/workflows/kill")
+def kill_switch(db: Session = Depends(get_db)):
+    """
+    Global kill switch — disable ALL workflows immediately (C1).
+
+    This is the "stop everything" button. Sets every workflow to enabled=False
+    in a single UPDATE. The worker checks workflow.enabled before processing
+    each job, so all processing stops within one poll cycle (~10-30 seconds).
+
+    C1 constraint: the broker must be able to stop all agent work at any time.
+    """
+    workflows = db.query(Workflow).all()
+    disabled_count = 0
+    for w in workflows:
+        if w.enabled:
+            w.enabled = False
+            w.updated_at = datetime.now(timezone.utc)
+            disabled_count += 1
+
+    # Audit the kill switch activation
+    event = AuditEvent(
+        event_type="kill_switch_activated",
+        actor="broker",
+        description=f"Kill switch activated — {disabled_count} workflow(s) disabled",
+        event_data={"disabled_count": disabled_count},
+    )
+    db.add(event)
+    db.commit()
+
+    logger.warning("KILL SWITCH activated — %d workflows disabled", disabled_count)
+
+    return {
+        "status": "all_disabled",
+        "disabled_count": disabled_count,
+    }
+
+
+@router.get("/api/settings/status")
+def get_system_status(db: Session = Depends(get_db)):
+    """
+    System status overview for the Settings page.
+
+    Returns cost cap configuration, mailbox provider status, and
+    workflow summary so the broker sees the system health at a glance.
+    """
+    # Cost caps from environment
+    daily_cap = os.environ.get("LLM_DAILY_COST_CAP", "20.00")
+    monthly_cap = os.environ.get("LLM_MONTHLY_COST_CAP", "100.00")
+
+    # Mailbox provider detection
+    graph_configured = bool(os.environ.get("MS_GRAPH_CLIENT_ID"))
+    imap_configured = bool(os.environ.get("IMAP_HOST"))
+    if graph_configured:
+        mailbox_provider = "Microsoft Graph"
+        mailbox_email = os.environ.get("MS_GRAPH_USER_EMAIL", "")
+    elif imap_configured:
+        mailbox_provider = "IMAP"
+        mailbox_email = os.environ.get("IMAP_USER", "")
+    else:
+        mailbox_provider = "File (demo)"
+        mailbox_email = ""
+
+    # Workflow summary
+    workflows = db.query(Workflow).all()
+    enabled_count = sum(1 for w in workflows if w.enabled)
+
+    return {
+        "cost_caps": {
+            "daily": float(daily_cap),
+            "monthly": float(monthly_cap),
+        },
+        "mailbox": {
+            "provider": mailbox_provider,
+            "email": mailbox_email,
+            "connected": graph_configured or imap_configured,
+        },
+        "workflows": {
+            "total": len(workflows),
+            "enabled": enabled_count,
+        },
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,7 @@ from backend.api.agent_runs import router as agent_runs_router
 from backend.api.dashboard import router as dashboard_router
 from backend.api.approvals import router as approvals_router
 from backend.api.carriers import router as carriers_router
+from backend.api.workflows import router as workflows_router
 from backend.api.dev import router as dev_router
 
 
@@ -125,6 +126,7 @@ app.include_router(agent_runs_router)
 app.include_router(dashboard_router)
 app.include_router(approvals_router)
 app.include_router(carriers_router)
+app.include_router(workflows_router)
 app.include_router(dev_router)
 @app.get("/api")
 def api_root():

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -1,0 +1,64 @@
+/**
+ * hooks/use-settings.ts — React Query hooks for Settings page (#31).
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+export interface WorkflowItem {
+  id: number
+  name: string
+  enabled: boolean
+  updated_at: string | null
+}
+
+interface WorkflowListResponse {
+  workflows: WorkflowItem[]
+}
+
+interface SystemStatus {
+  cost_caps: { daily: number; monthly: number }
+  mailbox: { provider: string; email: string; connected: boolean }
+  workflows: { total: number; enabled: number }
+}
+
+export function useWorkflows() {
+  return useQuery({
+    queryKey: ["workflows"],
+    queryFn: () => api.get<WorkflowListResponse>("/api/workflows"),
+  })
+}
+
+export function useSystemStatus() {
+  return useQuery({
+    queryKey: ["settings", "status"],
+    queryFn: () => api.get<SystemStatus>("/api/settings/status"),
+  })
+}
+
+export function useToggleWorkflow() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { id: number; enabled: boolean }) =>
+      fetch(`${import.meta.env.DEV ? "http://localhost:8001" : ""}/api/workflows/${params.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: params.enabled }),
+      }).then(r => r.json()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["settings"] })
+    },
+  })
+}
+
+export function useKillSwitch() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => api.post("/api/workflows/kill"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["settings"] })
+    },
+  })
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,36 +1,84 @@
 /**
- * pages/SettingsPage.tsx — Settings page with demo reseed button (#88).
+ * pages/SettingsPage.tsx — Settings page (#31, #44, #88).
  *
- * Currently provides a "Reset Demo Data" button that clears and reseeds
- * the database with realistic Beltmann demo scenarios. Future issues
- * will add workflow toggles (#31) and agent controls (#44).
+ * The broker's control center:
+ * - Workflow toggles (C1 — on/off per workflow)
+ * - Global kill switch (C1 — stop everything)
+ * - System status (cost caps, mailbox, worker)
+ * - Demo data reseed
+ *
+ * C1: The broker must be able to stop all agent work at any time.
  */
 
 import { useState } from "react"
-import { RotateCcw, AlertTriangle, Settings } from "lucide-react"
+import {
+  RotateCcw,
+  AlertTriangle,
+  Settings,
+  Power,
+  Mail,
+  DollarSign,
+  AlertOctagon,
+  CheckCircle,
+  XCircle,
+} from "lucide-react"
 import { toast } from "sonner"
 import { useQueryClient } from "@tanstack/react-query"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
 import { api } from "@/lib/api"
+import {
+  useWorkflows,
+  useSystemStatus,
+  useToggleWorkflow,
+  useKillSwitch,
+} from "@/hooks/use-settings"
 
 export function SettingsPage() {
-  const [isReseeding, setIsReseeding] = useState(false)
-  const [showConfirm, setShowConfirm] = useState(false)
+  const workflows = useWorkflows()
+  const status = useSystemStatus()
+  const toggleWorkflow = useToggleWorkflow()
+  const killSwitch = useKillSwitch()
   const queryClient = useQueryClient()
+
+  const [showReseedConfirm, setShowReseedConfirm] = useState(false)
+  const [showKillConfirm, setShowKillConfirm] = useState(false)
+  const [isReseeding, setIsReseeding] = useState(false)
+
+  const handleToggle = (id: number, currentlyEnabled: boolean) => {
+    const action = currentlyEnabled ? "disabled" : "enabled"
+    toggleWorkflow.mutate(
+      { id, enabled: !currentlyEnabled },
+      {
+        onSuccess: () => toast.success(`Workflow ${action}`),
+      }
+    )
+  }
+
+  const handleKillSwitch = () => {
+    setShowKillConfirm(false)
+    killSwitch.mutate(undefined, {
+      onSuccess: () => {
+        toast.error("Kill switch activated", {
+          description: "All workflows have been disabled",
+        })
+      },
+    })
+  }
 
   const handleReseed = async () => {
     setIsReseeding(true)
-    setShowConfirm(false)
+    setShowReseedConfirm(false)
     try {
       const result = await api.post<{ status: string; seeded: Record<string, number> }>(
         "/api/dev/reseed"
       )
-      // Invalidate all cached queries so the UI refreshes everywhere
       queryClient.invalidateQueries()
-      const counts = result.seeded
+      const c = result.seeded
       toast.success("Demo data reset", {
-        description: `Seeded ${counts.rfqs} RFQs, ${counts.messages} messages, ${counts.approvals} approvals`,
+        description: `Seeded ${c.rfqs} RFQs, ${c.messages} messages, ${c.carriers} carriers`,
       })
     } catch (err) {
       toast.error("Reseed failed", {
@@ -48,7 +96,146 @@ export function SettingsPage() {
         Settings
       </h2>
 
-      {/* Demo Data section */}
+      {/* Workflow Toggles (C1) */}
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Power className="h-4 w-4" />
+              Workflow Controls
+            </CardTitle>
+            {status.data && (
+              <Badge variant="secondary" className="text-xs">
+                {status.data.workflows.enabled} of {status.data.workflows.total} active
+              </Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {workflows.isLoading ? (
+            <div className="space-y-3">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="h-12 bg-muted/50 rounded animate-pulse" />
+              ))}
+            </div>
+          ) : (workflows.data?.workflows ?? []).length === 0 ? (
+            <p className="text-sm text-muted-foreground">No workflows configured</p>
+          ) : (
+            <>
+              {workflows.data?.workflows.map((wf) => (
+                <div key={wf.id} className="flex items-center justify-between py-2">
+                  <div>
+                    <p className="text-sm font-medium">{wf.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {wf.enabled ? "Running — processing jobs" : "Disabled — no new jobs"}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => handleToggle(wf.id, wf.enabled)}
+                    disabled={toggleWorkflow.isPending}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                      wf.enabled ? "bg-green-500" : "bg-gray-300"
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        wf.enabled ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                </div>
+              ))}
+
+              <Separator />
+
+              {/* Kill Switch */}
+              {showKillConfirm ? (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4 space-y-3">
+                  <div className="flex items-start gap-2">
+                    <AlertOctagon className="h-4 w-4 text-red-600 mt-0.5 shrink-0" />
+                    <p className="text-sm text-red-800">
+                      This will immediately disable ALL workflows. No new jobs will be processed
+                      until you re-enable them individually.
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      onClick={handleKillSwitch}
+                      disabled={killSwitch.isPending}
+                      className="bg-red-600 hover:bg-red-700 text-white"
+                    >
+                      {killSwitch.isPending ? "Stopping..." : "Confirm — Stop Everything"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setShowKillConfirm(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  onClick={() => setShowKillConfirm(true)}
+                  className="text-red-600 border-red-300 hover:bg-red-50"
+                >
+                  <AlertOctagon className="h-4 w-4 mr-2" />
+                  Kill Switch — Stop All Workflows
+                </Button>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* System Status */}
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base">System Status</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Mailbox */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Mail className="h-4 w-4 text-muted-foreground" />
+              <div>
+                <p className="text-sm font-medium">Email Provider</p>
+                <p className="text-xs text-muted-foreground">
+                  {status.data?.mailbox.provider ?? "Loading..."}
+                  {status.data?.mailbox.email && ` — ${status.data.mailbox.email}`}
+                </p>
+              </div>
+            </div>
+            {status.data?.mailbox.connected ? (
+              <Badge variant="secondary" className="bg-green-100 text-green-800 text-xs">
+                <CheckCircle className="h-3 w-3 mr-1" /> Connected
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="bg-gray-100 text-gray-600 text-xs">
+                <XCircle className="h-3 w-3 mr-1" /> Not connected
+              </Badge>
+            )}
+          </div>
+
+          <Separator />
+
+          {/* Cost Caps */}
+          <div className="flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">LLM Cost Caps</p>
+              <p className="text-xs text-muted-foreground">
+                Daily: ${status.data?.cost_caps.daily ?? "—"} · Monthly: ${status.data?.cost_caps.monthly ?? "—"}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Demo Data */}
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="text-base">Demo Data</CardTitle>
@@ -56,39 +243,28 @@ export function SettingsPage() {
         <CardContent className="space-y-4">
           <p className="text-sm text-muted-foreground">
             Reset all data to a fresh demo state with realistic Beltmann scenarios.
-            This clears everything and reseeds RFQs, messages, approvals, and activity.
           </p>
-
-          {showConfirm ? (
+          {showReseedConfirm ? (
             <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 space-y-3">
               <div className="flex items-start gap-2">
                 <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
                 <p className="text-sm text-amber-800">
                   This will delete all existing data and replace it with demo data.
-                  This cannot be undone.
                 </p>
               </div>
               <div className="flex gap-2">
                 <Button
+                  size="sm"
                   onClick={handleReseed}
                   disabled={isReseeding}
                   className="bg-red-600 hover:bg-red-700 text-white"
-                  size="sm"
                 >
-                  {isReseeding ? (
-                    <>
-                      <RotateCcw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                      Reseeding...
-                    </>
-                  ) : (
-                    "Yes, reset all data"
-                  )}
+                  {isReseeding ? "Reseeding..." : "Yes, reset all data"}
                 </Button>
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setShowConfirm(false)}
-                  disabled={isReseeding}
+                  onClick={() => setShowReseedConfirm(false)}
                 >
                   Cancel
                 </Button>
@@ -97,36 +273,13 @@ export function SettingsPage() {
           ) : (
             <Button
               variant="outline"
-              onClick={() => setShowConfirm(true)}
+              onClick={() => setShowReseedConfirm(true)}
               className="text-amber-700 border-amber-300 hover:bg-amber-50"
             >
               <RotateCcw className="h-4 w-4 mr-2" />
               Reset Demo Data
             </Button>
           )}
-        </CardContent>
-      </Card>
-
-      {/* Placeholder for future settings */}
-      <Card className="shadow-sm">
-        <CardHeader>
-          <CardTitle className="text-base">Workflow Controls</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Workflow toggles and kill switch coming in issue #31.
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card className="shadow-sm">
-        <CardHeader>
-          <CardTitle className="text-base">Agent Permissions</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Per-agent permissions and cost caps coming in issue #44.
-          </p>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

Closes #31 — Settings page with C1 workflow controls.

### Backend
- **GET `/api/workflows`** — list with enabled status
- **PUT `/api/workflows/{id}`** — toggle on/off
- **POST `/api/workflows/kill`** — global kill switch
- **GET `/api/settings/status`** — cost caps, mailbox, workflow summary

### Frontend
- Per-workflow toggle switches
- Kill switch with red confirmation
- System status (email provider, cost caps)
- Demo reseed (existing from #88)

## Test plan
- [x] `npm run build` — zero TS errors
- [ ] Settings page shows workflow toggles
- [ ] Toggle a workflow → status changes
- [ ] Kill switch → all workflows disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)