### PR TITLE
#113 — Setting to toggle cost visibility

### DIFF
--- a/frontend/src/components/agent/DecisionsTab.tsx
+++ b/frontend/src/components/agent/DecisionsTab.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
+import { useCostVisibility } from "@/lib/cost-visibility"
 import { Card, CardContent } from "@/components/ui/card"
 import { useAgentRuns, useAgentRunDetail } from "@/hooks/use-agent-runs"
 import { formatRelativeTime } from "@/lib/utils"
@@ -18,6 +19,7 @@ export function DecisionsTab() {
   const [selectedRunId, setSelectedRunId] = useState<number | null>(null)
   const detail = useAgentRunDetail(selectedRunId)
   const [expandedCallId, setExpandedCallId] = useState<number | null>(null)
+  const { showCost } = useCostVisibility()
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
@@ -45,7 +47,7 @@ export function DecisionsTab() {
             >
               <p className="text-sm font-medium">{run.workflow_name}</p>
               <p className="text-xs text-muted-foreground">
-                {run.started_at ? formatRelativeTime(run.started_at) : "—"} · ${run.total_cost_usd.toFixed(4)}
+                {run.started_at ? formatRelativeTime(run.started_at) : "—"}{showCost ? ` · $${run.total_cost_usd.toFixed(4)}` : ""}
               </p>
             </button>
           ))
@@ -83,7 +85,7 @@ export function DecisionsTab() {
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground">
                     <span>{call.input_tokens + call.output_tokens} tokens</span>
-                    <span>${call.cost_usd.toFixed(4)}</span>
+                    {showCost && <span>${call.cost_usd.toFixed(4)}</span>}
                     <span>{call.duration_ms ? `${(call.duration_ms / 1000).toFixed(1)}s` : "—"}</span>
                   </div>
                 </div>

--- a/frontend/src/components/agent/TimelineTab.tsx
+++ b/frontend/src/components/agent/TimelineTab.tsx
@@ -13,6 +13,7 @@ import { ChevronDown, ChevronRight } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { useAgentRuns, useAgentRunDetail } from "@/hooks/use-agent-runs"
+import { useCostVisibility } from "@/lib/cost-visibility"
 import { formatRelativeTime, cn } from "@/lib/utils"
 
 const statusColors: Record<string, string> = {
@@ -100,6 +101,7 @@ function RunRow({
 }) {
   const detail = useAgentRunDetail(isExpanded ? run.id : null)
   const durationSec = run.duration_ms ? (run.duration_ms / 1000).toFixed(1) : "—"
+  const { showCost } = useCostVisibility()
 
   return (
     <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
@@ -132,7 +134,7 @@ function RunRow({
         <div className="hidden sm:flex items-center gap-3 shrink-0">
           <div className="text-right">
             <p className="text-xs font-mono">{durationSec}s</p>
-            <p className="text-[10px] text-muted-foreground">${run.total_cost_usd.toFixed(4)}</p>
+            {showCost && <p className="text-[10px] text-muted-foreground">${run.total_cost_usd.toFixed(4)}</p>}
           </div>
           <div className="w-24 h-2 bg-muted rounded-full overflow-hidden">
             <div
@@ -177,6 +179,7 @@ function RunRow({
 }
 
 function CallRow({ call }: { call: { id: number; agent_name: string; model: string; provider: string; status: string; input_tokens: number; output_tokens: number; cost_usd: number; duration_ms: number | null } }) {
+  const { showCost } = useCostVisibility()
   return (
     <div className="flex items-center justify-between bg-white rounded p-2 border text-xs">
       <div>
@@ -185,7 +188,7 @@ function CallRow({ call }: { call: { id: number; agent_name: string; model: stri
       </div>
       <div className="flex items-center gap-3 text-muted-foreground">
         <span>{call.input_tokens + call.output_tokens} tokens</span>
-        <span>${call.cost_usd.toFixed(4)}</span>
+        {showCost && <span>${call.cost_usd.toFixed(4)}</span>}
         <span>{call.duration_ms ? `${(call.duration_ms / 1000).toFixed(1)}s` : "—"}</span>
         <Badge variant="secondary" className={`text-[9px] ${statusColors[call.status] ?? ""}`}>
           {call.status}

--- a/frontend/src/lib/cost-visibility.tsx
+++ b/frontend/src/lib/cost-visibility.tsx
@@ -1,0 +1,47 @@
+/**
+ * lib/cost-visibility.tsx — Cost visibility context (#113).
+ *
+ * Provides a global toggle for showing/hiding cost information across
+ * agent views (Decisions, Timeline, Controls). Stored in localStorage
+ * so it persists across sessions. Default: visible (on).
+ *
+ * Usage:
+ *   const { showCost } = useCostVisibility()
+ *   {showCost && <span>${cost}</span>}
+ */
+
+import { createContext, useContext, useState, type ReactNode } from "react"
+
+interface CostVisibilityContextType {
+  showCost: boolean
+  setShowCost: (show: boolean) => void
+}
+
+const STORAGE_KEY = "golteris_show_cost"
+
+const CostVisibilityContext = createContext<CostVisibilityContextType>({
+  showCost: true,
+  setShowCost: () => {},
+})
+
+export function CostVisibilityProvider({ children }: { children: ReactNode }) {
+  const [showCost, setShowCostState] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored !== null ? stored === "true" : true
+  })
+
+  const setShowCost = (show: boolean) => {
+    setShowCostState(show)
+    localStorage.setItem(STORAGE_KEY, String(show))
+  }
+
+  return (
+    <CostVisibilityContext.Provider value={{ showCost, setShowCost }}>
+      {children}
+    </CostVisibilityContext.Provider>
+  )
+}
+
+export function useCostVisibility() {
+  return useContext(CostVisibilityContext)
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { Toaster } from "@/components/ui/sonner"
 import { AuthProvider, useAuth } from "@/lib/auth"
+import { CostVisibilityProvider } from "@/lib/cost-visibility"
 import App from "./App"
 import { LoginPage } from "./pages/LoginPage"
 import { DashboardPage } from "./pages/DashboardPage"
@@ -72,9 +73,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <BrowserRouter>
-          <AuthGate />
-        </BrowserRouter>
+        <CostVisibilityProvider>
+          <BrowserRouter>
+            <AuthGate />
+          </BrowserRouter>
+        </CostVisibilityProvider>
       </AuthProvider>
       <Toaster position="bottom-right" richColors />
     </QueryClientProvider>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import {
   CheckCircle,
   XCircle,
   Bot,
+  Eye,
 } from "lucide-react"
 import { toast } from "sonner"
 import { useQueryClient } from "@tanstack/react-query"
@@ -38,6 +39,7 @@ import {
   useAgentControls,
   useUpdateAgent,
 } from "@/hooks/use-settings"
+import { useCostVisibility } from "@/lib/cost-visibility"
 
 export function SettingsPage() {
   const workflows = useWorkflows()
@@ -48,6 +50,7 @@ export function SettingsPage() {
   const updateAgent = useUpdateAgent()
   const queryClient = useQueryClient()
 
+  const { showCost, setShowCost } = useCostVisibility()
   const [showReseedConfirm, setShowReseedConfirm] = useState(false)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
   const [isClearing, setIsClearing] = useState(false)
@@ -238,6 +241,36 @@ export function SettingsPage() {
                 Daily: ${status.data?.cost_caps.daily ?? "—"} · Monthly: ${status.data?.cost_caps.monthly ?? "—"}
               </p>
             </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Display Preferences (#113) */}
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Eye className="h-4 w-4" />
+            Display
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between py-2">
+            <div>
+              <p className="text-sm font-medium">Show cost information</p>
+              <p className="text-xs text-muted-foreground">
+                Display LLM costs in Agent decisions, timeline, and controls
+              </p>
+            </div>
+            <button
+              onClick={() => setShowCost(!showCost)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                showCost ? "bg-green-500" : "bg-gray-300"
+              }`}
+            >
+              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                showCost ? "translate-x-6" : "translate-x-1"
+              }`} />
+            </button>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
Closes #113

## Summary
- New `CostVisibilityProvider` context stored in localStorage
- Toggle on Settings page under "Display" card
- When off, hides cost data in Agent Decisions and Timeline views
- Default: on

## Test plan
- [ ] Settings → Display → toggle "Show cost information" off
- [ ] Agent → Decisions tab → cost columns hidden
- [ ] Agent → Timeline tab → cost per run hidden, cost per call hidden
- [ ] Toggle back on → costs reappear
- [ ] Refresh page → setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)