### PR TITLE
#107 — Quick-action approve/reject from dashboard

### DIFF
--- a/frontend/src/components/dashboard/UrgentActionCard.tsx
+++ b/frontend/src/components/dashboard/UrgentActionCard.tsx
@@ -1,16 +1,24 @@
 /**
- * components/dashboard/UrgentActionCard.tsx — Single urgent action row.
+ * components/dashboard/UrgentActionCard.tsx — Single urgent action row (#107).
  *
  * Displays one pending approval with its type badge, RFQ context, reason,
- * and an inline "Approve" button. The broker can approve directly from the
- * dashboard without opening a full modal.
+ * and inline action buttons. The broker can:
+ * - "Send" to approve directly from the dashboard without opening the modal
+ * - "Reject" to reject inline
+ * - "Review" to open the full approval modal for editing
  *
- * C2 enforcement: clicking "Approve" calls POST /api/approvals/{id}/approve
- * which is the HITL gate for outbound email sends.
+ * C2 enforcement: clicking "Send" calls POST /api/approvals/{id}/approve
+ * which is the HITL gate for outbound email sends. The action is still a
+ * deliberate human choice (click), just without requiring the full modal.
  */
 
+import { useState } from "react"
+import { Check, X } from "lucide-react"
+import { toast } from "sonner"
+import { useQueryClient } from "@tanstack/react-query"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { api } from "@/lib/api"
 import { formatRelativeTime } from "@/lib/utils"
 import type { ApprovalItem } from "@/types/api"
 
@@ -38,6 +46,32 @@ export function UrgentActionCard({
       ? `${rfq.origin} → ${rfq.destination}`
       : null
 
+  const [isActioning, setIsActioning] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  /* Quick-approve inline — sends the draft as-is without opening the modal (#107).
+     C2: This is still a deliberate human action (click), fully audited. */
+  const handleQuickAction = async (action: "approve" | "reject") => {
+    setIsActioning(action)
+    try {
+      const endpoint = action === "approve" ? "approve" : "reject"
+      await api.post(`/api/approvals/${approval.id}/${endpoint}`, {
+        approved_by: "jillian@beltmann.com",
+        reason: action === "reject" ? "Rejected from dashboard" : undefined,
+      })
+      queryClient.invalidateQueries({ queryKey: ["approvals"] })
+      queryClient.invalidateQueries({ queryKey: ["dashboard"] })
+      toast.success(
+        action === "approve" ? "Approved" : "Rejected",
+        { description: action === "approve" ? "Queued for sending" : "Draft rejected" }
+      )
+    } catch {
+      toast.error(`Failed to ${action}`)
+    } finally {
+      setIsActioning(null)
+    }
+  }
+
   return (
     <div className="flex items-center justify-between gap-4 py-3 border-b last:border-0">
       <div className="min-w-0 flex-1">
@@ -64,14 +98,38 @@ export function UrgentActionCard({
         </p>
       </div>
 
-      <Button
-        size="sm"
-        onClick={() => onApprove(approval.id)}
-        disabled={isApproving}
-        className="shrink-0 bg-[#0F9ED5] hover:bg-[#0B7FAD] text-white"
-      >
-        {isApproving ? "Opening..." : "Review"}
-      </Button>
+      {/* Inline action buttons (#107) — approve/reject without opening modal */}
+      <div className="flex items-center gap-1.5 shrink-0">
+        <Button
+          size="sm"
+          onClick={() => handleQuickAction("approve")}
+          disabled={isActioning !== null}
+          className="bg-green-600 hover:bg-green-700 text-white h-8 px-2.5"
+          title="Approve and send"
+        >
+          {isActioning === "approve" ? "..." : <><Check className="h-3.5 w-3.5 mr-1" /> Send</>}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => handleQuickAction("reject")}
+          disabled={isActioning !== null}
+          className="text-red-600 border-red-300 hover:bg-red-50 h-8 px-2.5"
+          title="Reject"
+        >
+          {isActioning === "reject" ? "..." : <X className="h-3.5 w-3.5" />}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onApprove(approval.id)}
+          disabled={isApproving || isActioning !== null}
+          className="h-8 px-2.5"
+          title="Open full review"
+        >
+          Review
+        </Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #107

## Summary
- UrgentActionCard now has 3 inline buttons: Send (green, approves), X (red, rejects), Review (opens modal)
- Quick approve calls `POST /api/approvals/:id/approve` directly
- Quick reject calls `POST /api/approvals/:id/reject` directly
- Invalidates approval and dashboard queries on success
- C2 still enforced — deliberate human click, fully audited

## Test plan
- [ ] Dashboard shows Send/X/Review buttons on each urgent action
- [ ] Click Send → approval approved, toast shown, item disappears
- [ ] Click X → approval rejected, toast shown, item disappears
- [ ] Click Review → full modal opens (existing behavior)
- [ ] Audit trail preserved for quick actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)