### PR TITLE
#108 — Export RFQs as CSV

### DIFF
--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,0 +1,53 @@
+/**
+ * lib/export.ts — CSV export utility (#108).
+ *
+ * Generates a CSV file from an array of objects and triggers a browser
+ * download. Used by the RFQs page and dashboard export buttons.
+ */
+
+/**
+ * Export an array of objects to a CSV file and trigger a browser download.
+ *
+ * @param data - Array of row objects
+ * @param columns - Column definitions: { key, label } pairs
+ * @param filename - Download filename (without extension)
+ */
+export function exportToCsv<T extends Record<string, unknown>>(
+  data: T[],
+  columns: { key: keyof T; label: string }[],
+  filename: string
+) {
+  if (data.length === 0) return
+
+  /* Build CSV header row */
+  const header = columns.map((c) => escapeCsvField(c.label)).join(",")
+
+  /* Build CSV data rows */
+  const rows = data.map((row) =>
+    columns
+      .map((c) => {
+        const value = row[c.key]
+        return escapeCsvField(value == null ? "" : String(value))
+      })
+      .join(",")
+  )
+
+  const csv = [header, ...rows].join("\n")
+
+  /* Trigger browser download */
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = `${filename}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+/** Escape a CSV field value — wrap in quotes if it contains commas, quotes, or newlines. */
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}

--- a/frontend/src/pages/RfqsPage.tsx
+++ b/frontend/src/pages/RfqsPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useMemo } from "react"
-import { Search } from "lucide-react"
+import { Search, Download } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import {
   Table,
@@ -28,6 +28,7 @@ import { RfqDetailDrawer } from "@/components/dashboard/RfqDetailDrawer"
 import { useRfqList, useRfqCounts } from "@/hooks/use-rfq-list"
 import { formatRelativeTime } from "@/lib/utils"
 import { cn } from "@/lib/utils"
+import { exportToCsv } from "@/lib/export"
 
 /** State filter options with plain-English labels (C3) and colors. */
 const STATE_FILTERS = [
@@ -101,16 +102,45 @@ export function RfqsPage() {
           )}
         </h2>
 
-        {/* Search input */}
-        <div className="relative w-full sm:w-72">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <input
-            type="text"
-            placeholder="Search shipper, route..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 text-sm border rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-[#0F9ED5]/30 focus:border-[#0F9ED5]"
-          />
+        {/* Search + Export */}
+        <div className="flex items-center gap-2">
+          <div className="relative w-full sm:w-72">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search shipper, route..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 text-sm border rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-[#0F9ED5]/30 focus:border-[#0F9ED5]"
+            />
+          </div>
+          {/* Export CSV button (#108) */}
+          <button
+            onClick={() => {
+              const data = rfqs.data?.rfqs ?? []
+              exportToCsv(
+                data,
+                [
+                  { key: "id", label: "RFQ #" },
+                  { key: "customer_name", label: "Customer" },
+                  { key: "customer_company", label: "Company" },
+                  { key: "origin", label: "Origin" },
+                  { key: "destination", label: "Destination" },
+                  { key: "equipment_type", label: "Equipment" },
+                  { key: "truck_count", label: "Trucks" },
+                  { key: "state_label", label: "Status" },
+                  { key: "created_at", label: "Created" },
+                ],
+                `golteris-rfqs-${new Date().toISOString().slice(0, 10)}`
+              )
+            }}
+            disabled={!rfqs.data?.rfqs.length}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-2 text-xs border rounded-md bg-white hover:bg-muted/50 disabled:opacity-40"
+            title="Download as CSV"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Export
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #108

## Summary
- New `lib/export.ts` utility — generates CSV from data arrays with proper escaping
- "Export" button on the RFQs page header downloads the current filtered list as CSV
- Columns: RFQ #, Customer, Company, Origin, Destination, Equipment, Trucks, Status, Created
- Filename includes date: `golteris-rfqs-2026-04-07.csv`

## Test plan
- [ ] RFQs page shows "Export" button next to search
- [ ] Click Export → CSV file downloads
- [ ] CSV contains correct headers and data
- [ ] Apply a filter → export reflects the filtered data
- [ ] Empty list → button disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)