### PR TITLE
#133 — Graph webhook push notifications for real-time email

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -342,3 +342,113 @@ def _count_fields(rfq: RFQ) -> int:
     fields = [rfq.customer_name, rfq.origin, rfq.destination, rfq.equipment_type,
               rfq.commodity, rfq.weight_lbs, rfq.truck_count, rfq.pickup_date]
     return sum(1 for f in fields if f is not None)
+
+
+# ---------------------------------------------------------------------------
+# Graph webhook subscription management (#133)
+# ---------------------------------------------------------------------------
+
+# In-memory subscription tracking (persisted to DB in a future iteration)
+_graph_subscription: Optional[dict] = None
+
+
+@router.post("/graph/subscribe")
+def create_graph_subscription(db: Session = Depends(get_db)):
+    """
+    Create a Microsoft Graph webhook subscription for real-time email push.
+
+    Requires a publicly accessible HTTPS URL. On Render, this is automatic.
+    For local dev, use a tunnel (ngrok) and set GRAPH_WEBHOOK_URL env var.
+    """
+    global _graph_subscription
+
+    webhook_url = os.environ.get("GRAPH_WEBHOOK_URL", "")
+    if not webhook_url:
+        return {
+            "status": "error",
+            "message": "GRAPH_WEBHOOK_URL not set. Set it to your public URL + /api/webhooks/graph (e.g., https://app.golteris.com/api/webhooks/graph)",
+        }
+
+    from backend.services.graph_subscriptions import create_subscription
+    from backend.api.webhooks import GRAPH_WEBHOOK_SECRET
+
+    sub = create_subscription(webhook_url, client_state=GRAPH_WEBHOOK_SECRET)
+    if sub:
+        _graph_subscription = sub
+        return {
+            "status": "ok",
+            "message": "Graph webhook subscription created",
+            "subscription": {
+                "id": sub.get("id"),
+                "resource": sub.get("resource"),
+                "expiration": sub.get("expirationDateTime"),
+            },
+        }
+    else:
+        return {"status": "error", "message": "Failed to create subscription — check server logs"}
+
+
+@router.delete("/graph/subscribe")
+def delete_graph_subscription():
+    """Delete the active Graph webhook subscription (stop push notifications)."""
+    global _graph_subscription
+
+    if not _graph_subscription:
+        return {"status": "error", "message": "No active subscription"}
+
+    from backend.services.graph_subscriptions import delete_subscription
+
+    sub_id = _graph_subscription.get("id", "")
+    if delete_subscription(sub_id):
+        _graph_subscription = None
+        return {"status": "ok", "message": "Subscription deleted — falling back to polling"}
+    else:
+        return {"status": "error", "message": "Failed to delete subscription"}
+
+
+@router.get("/graph/subscribe")
+def get_graph_subscription_status():
+    """Get the current Graph webhook subscription status."""
+    global _graph_subscription
+
+    if not _graph_subscription:
+        return {
+            "active": False,
+            "mode": "polling",
+            "message": "No webhook subscription — using poll mode",
+        }
+
+    from backend.services.graph_subscriptions import needs_renewal
+
+    expiry = _graph_subscription.get("expirationDateTime", "")
+    return {
+        "active": True,
+        "mode": "webhook",
+        "subscription_id": _graph_subscription.get("id"),
+        "resource": _graph_subscription.get("resource"),
+        "expiration": expiry,
+        "needs_renewal": needs_renewal(expiry) if expiry else True,
+    }
+
+
+@router.post("/graph/renew")
+def renew_graph_subscription():
+    """Renew the Graph webhook subscription before it expires."""
+    global _graph_subscription
+
+    if not _graph_subscription:
+        return {"status": "error", "message": "No active subscription to renew"}
+
+    from backend.services.graph_subscriptions import renew_subscription
+
+    sub_id = _graph_subscription.get("id", "")
+    renewed = renew_subscription(sub_id)
+    if renewed:
+        _graph_subscription = renewed
+        return {
+            "status": "ok",
+            "message": "Subscription renewed",
+            "expiration": renewed.get("expirationDateTime"),
+        }
+    else:
+        return {"status": "error", "message": "Renewal failed — may need to recreate"}

--- a/backend/api/webhooks.py
+++ b/backend/api/webhooks.py
@@ -1,0 +1,225 @@
+"""
+backend/api/webhooks.py — Webhook endpoints for email push notifications (#133).
+
+Handles Microsoft Graph change notifications so new emails appear in
+Golteris within seconds instead of waiting for the poll interval.
+
+Graph webhook flow:
+    1. We create a subscription via POST /subscriptions on Graph API
+    2. Graph validates our endpoint by sending GET with ?validationToken=xxx
+    3. We respond with the token in plain text (200 OK)
+    4. When a new email arrives, Graph POSTs a notification with the message resource
+    5. We fetch that specific message and ingest it immediately
+
+Endpoints:
+    POST /api/webhooks/graph  — Receives Graph change notifications
+                                Also handles validation during subscription creation
+
+Security:
+    - Validates clientState token on every notification (prevents spoofing)
+    - Rejects notifications with missing or invalid clientState
+
+Cross-cutting constraints:
+    FR-EI-1 — Persists sender, recipients, subject, body, timestamps, thread metadata
+    C4 — Audit event for every ingested message
+"""
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from backend.db.database import get_db
+
+logger = logging.getLogger("golteris.webhooks.graph")
+
+router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
+
+# Secret token we include when creating the subscription — Graph echoes it
+# back on every notification so we can verify it's legitimate.
+GRAPH_WEBHOOK_SECRET = os.environ.get("GRAPH_WEBHOOK_SECRET", "golteris-graph-webhook-secret")
+
+
+@router.post("/graph")
+async def graph_webhook(request: Request, db: Session = Depends(get_db)):
+    """
+    Receive Microsoft Graph change notifications for new emails.
+
+    This endpoint serves two purposes:
+    1. **Validation** — When we create a subscription, Graph sends a POST with
+       a validationToken query param. We must respond with the token in plain
+       text within 10 seconds.
+    2. **Notifications** — When a new email arrives, Graph sends a POST with
+       a JSON body containing the changed resource. We fetch and ingest it.
+    """
+    # --- Subscription validation ---
+    # Graph sends validationToken as a query param during subscription creation.
+    # We must echo it back as plain text to prove we own the endpoint.
+    validation_token = request.query_params.get("validationToken")
+    if validation_token:
+        logger.info("Graph webhook validation — responding with token")
+        return PlainTextResponse(content=validation_token, status_code=200)
+
+    # --- Change notification ---
+    try:
+        body = await request.json()
+    except Exception:
+        logger.error("Graph webhook — invalid JSON body")
+        return Response(status_code=400)
+
+    notifications = body.get("value", [])
+    if not notifications:
+        logger.debug("Graph webhook — empty notification, ignoring")
+        return Response(status_code=202)
+
+    ingested_count = 0
+
+    for notification in notifications:
+        # Verify clientState to prevent spoofed notifications
+        client_state = notification.get("clientState", "")
+        if client_state != GRAPH_WEBHOOK_SECRET:
+            logger.warning("Graph webhook — invalid clientState, rejecting notification")
+            continue
+
+        change_type = notification.get("changeType", "")
+        resource = notification.get("resource", "")
+
+        # We only care about new messages (created)
+        if change_type != "created":
+            logger.debug("Graph webhook — ignoring changeType=%s", change_type)
+            continue
+
+        # resource looks like: "users/{user-id}/messages/{message-id}"
+        # or "users/{user-id}/mailFolders/{folder-id}/messages/{message-id}"
+        logger.info("Graph webhook — new message notification: %s", resource)
+
+        try:
+            ingested = _fetch_and_ingest_message(db, resource)
+            if ingested:
+                ingested_count += 1
+        except Exception as e:
+            logger.exception("Graph webhook — failed to process notification: %s", e)
+
+    if ingested_count > 0:
+        logger.info("Graph webhook — ingested %d new messages", ingested_count)
+
+    # Graph requires 202 Accepted response within 30 seconds
+    return Response(status_code=202)
+
+
+def _fetch_and_ingest_message(db: Session, resource: str) -> bool:
+    """
+    Fetch a specific message from Graph API and ingest it.
+
+    The resource path from the notification tells us exactly which message
+    to fetch, so we don't need to scan the entire mailbox.
+
+    Args:
+        db: SQLAlchemy session
+        resource: Graph resource path (e.g., "users/{id}/messages/{id}")
+
+    Returns:
+        True if a message was ingested, False if skipped (duplicate, filtered, etc.)
+    """
+    import requests
+    import msal
+
+    tenant_id = os.environ.get("MS_GRAPH_TENANT_ID", "")
+    client_id = os.environ.get("MS_GRAPH_CLIENT_ID", "")
+    client_secret = os.environ.get("MS_GRAPH_CLIENT_SECRET", "")
+    filter_recipient = os.environ.get("MS_GRAPH_FILTER_RECIPIENT", "")
+
+    if not client_id or not tenant_id:
+        logger.error("Graph API not configured — cannot process webhook notification")
+        return False
+
+    # Get access token
+    app = msal.ConfidentialClientApplication(
+        client_id,
+        authority=f"https://login.microsoftonline.com/{tenant_id}",
+        client_credential=client_secret,
+    )
+    result = app.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
+    token = result.get("access_token")
+    if not token:
+        logger.error("Graph auth failed for webhook processing")
+        return False
+
+    # Fetch the specific message
+    url = f"https://graph.microsoft.com/v1.0/{resource}"
+    params = {
+        "$select": "id,subject,from,toRecipients,ccRecipients,body,receivedDateTime,conversationId,internetMessageId,internetMessageHeaders,isRead"
+    }
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, params=params)
+
+    if resp.status_code != 200:
+        logger.error("Graph webhook — failed to fetch message: %d %s", resp.status_code, resp.text[:200])
+        return False
+
+    raw_msg = resp.json()
+
+    # Apply recipient filter if configured (same logic as the poll provider)
+    if filter_recipient:
+        from backend.email.graph_provider import GraphMailboxProvider
+        provider = GraphMailboxProvider()
+        if not provider._is_addressed_to(raw_msg, filter_recipient):
+            logger.debug("Graph webhook — message not addressed to %s, skipping", filter_recipient)
+            # Mark as read so it doesn't clog the unread count
+            _mark_as_read(token, resource)
+            return False
+
+    # Parse the message using the existing Graph provider
+    from backend.email.graph_provider import GraphMailboxProvider
+    provider = GraphMailboxProvider()
+    parsed = provider._parse_message(raw_msg)
+
+    if not parsed:
+        logger.error("Graph webhook — failed to parse message")
+        return False
+
+    # Ingest using the existing service (handles dedup, persist, enqueue jobs)
+    from backend.services.email_ingestion import ingest_new_messages
+    from backend.email.provider import MailboxProvider, InboundMessage
+
+    # Create a minimal provider that returns just this one message
+    class SingleMessageProvider(MailboxProvider):
+        def __init__(self, msg: InboundMessage):
+            self._msg = msg
+            self._consumed = False
+
+        def fetch_new_messages(self) -> list[InboundMessage]:
+            if self._consumed:
+                return []
+            self._consumed = True
+            return [self._msg]
+
+        def send_message(self, to, subject, body, reply_to_message_id=None):
+            raise NotImplementedError("Webhook provider does not send")
+
+        def get_provider_name(self):
+            return "graph-webhook"
+
+    messages = ingest_new_messages(db, SingleMessageProvider(parsed))
+
+    # Mark as read on Graph so it doesn't show up in polling too
+    if messages:
+        _mark_as_read(token, resource)
+
+    return len(messages) > 0
+
+
+def _mark_as_read(token: str, resource: str) -> None:
+    """Mark a message as read on Graph to prevent re-processing by the poller."""
+    import requests
+    try:
+        # Extract the message URL from the resource path
+        url = f"https://graph.microsoft.com/v1.0/{resource}"
+        requests.patch(
+            url,
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            json={"isRead": True},
+        )
+    except Exception as e:
+        logger.error("Graph webhook — failed to mark message as read: %s", e)

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ from backend.api.jobs import router as jobs_router
 from backend.api.dev import router as dev_router
 from backend.api.mailboxes import router as mailboxes_router
 from backend.api.admin import router as admin_router
+from backend.api.webhooks import router as webhooks_router
 from backend.api.metrics import router as metrics_router
 from backend.api.summary import router as summary_router
 from backend.api.memories import router as memories_router
@@ -167,6 +168,7 @@ app.include_router(metering_router)
 app.include_router(billing_router)
 app.include_router(onboarding_router)
 app.include_router(admin_router)
+app.include_router(webhooks_router)
 @app.get("/api")
 def api_root():
     """

--- a/backend/services/graph_subscriptions.py
+++ b/backend/services/graph_subscriptions.py
@@ -1,0 +1,265 @@
+"""
+backend/services/graph_subscriptions.py — Microsoft Graph subscription management (#133).
+
+Creates, renews, and deletes Graph change notification subscriptions for
+real-time email push. Graph subscriptions have a max lifetime of 3 days
+(4230 minutes) and must be renewed before expiry.
+
+Subscription lifecycle:
+    1. create_subscription() — called from admin API or on startup
+    2. Graph validates our webhook URL (sends validationToken)
+    3. Subscription active — Graph pushes notifications for new emails
+    4. renew_subscription() — called before expiry (worker or scheduler)
+    5. delete_subscription() — called on mailbox disconnect or app shutdown
+
+Called by:
+    - POST /api/admin/graph/subscribe (admin UI)
+    - Worker scheduler (auto-renewal)
+
+Cross-cutting constraints:
+    C1 — Subscription can be stopped by the admin at any time
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import msal
+import requests
+
+logger = logging.getLogger("golteris.services.graph_subscriptions")
+
+GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+# Max subscription lifetime for mail resources is 4230 minutes (~2.94 days)
+MAX_SUBSCRIPTION_MINUTES = 4230
+# Renew when less than this many minutes remain
+RENEWAL_THRESHOLD_MINUTES = 60
+
+
+def create_subscription(
+    webhook_url: str,
+    client_state: str = "",
+) -> Optional[dict]:
+    """
+    Create a Graph change notification subscription for new emails.
+
+    Subscribes to the configured mailbox's messages resource. Graph will
+    send POST notifications to webhook_url when new emails arrive.
+
+    Args:
+        webhook_url: The publicly accessible URL for our webhook endpoint
+                     (e.g., "https://app.golteris.com/api/webhooks/graph")
+        client_state: Secret token included in each notification for verification
+
+    Returns:
+        Subscription dict from Graph (id, expirationDateTime, resource) or None on failure
+    """
+    token = _get_token()
+    if not token:
+        return None
+
+    user_email = os.environ.get("MS_GRAPH_USER_EMAIL", "")
+    mail_folder = os.environ.get("MS_GRAPH_MAIL_FOLDER", "")
+
+    if not user_email:
+        logger.error("MS_GRAPH_USER_EMAIL not set — cannot create subscription")
+        return None
+
+    # Build the resource path — subscribe to messages in the configured folder
+    if mail_folder:
+        # Need to resolve folder ID first
+        folder_id = _resolve_folder_id(token, user_email, mail_folder)
+        if folder_id:
+            resource = f"users/{user_email}/mailFolders/{folder_id}/messages"
+        else:
+            logger.warning("Folder '%s' not found — subscribing to all messages", mail_folder)
+            resource = f"users/{user_email}/messages"
+    else:
+        resource = f"users/{user_email}/messages"
+
+    # Expiration — max 4230 minutes from now
+    expiration = datetime.now(timezone.utc) + timedelta(minutes=MAX_SUBSCRIPTION_MINUTES)
+
+    payload = {
+        "changeType": "created",
+        "notificationUrl": webhook_url,
+        "resource": resource,
+        "expirationDateTime": expiration.isoformat(),
+        "clientState": client_state,
+    }
+
+    logger.info("Creating Graph subscription: resource=%s, webhook=%s", resource, webhook_url)
+
+    try:
+        resp = requests.post(
+            f"{GRAPH_BASE_URL}/subscriptions",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+
+        if resp.status_code in (200, 201):
+            sub = resp.json()
+            logger.info(
+                "Graph subscription created: id=%s, expires=%s",
+                sub.get("id"), sub.get("expirationDateTime"),
+            )
+            return sub
+        else:
+            logger.error(
+                "Graph subscription creation failed (%d): %s",
+                resp.status_code, resp.text[:500],
+            )
+            return None
+
+    except Exception as e:
+        logger.exception("Graph subscription creation error: %s", e)
+        return None
+
+
+def renew_subscription(subscription_id: str) -> Optional[dict]:
+    """
+    Renew an existing Graph subscription before it expires.
+
+    Extends the expiration by the maximum allowed duration.
+
+    Args:
+        subscription_id: The Graph subscription ID to renew
+
+    Returns:
+        Updated subscription dict or None on failure
+    """
+    token = _get_token()
+    if not token:
+        return None
+
+    new_expiration = datetime.now(timezone.utc) + timedelta(minutes=MAX_SUBSCRIPTION_MINUTES)
+
+    try:
+        resp = requests.patch(
+            f"{GRAPH_BASE_URL}/subscriptions/{subscription_id}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={"expirationDateTime": new_expiration.isoformat()},
+            timeout=30,
+        )
+
+        if resp.status_code == 200:
+            sub = resp.json()
+            logger.info("Graph subscription renewed: id=%s, expires=%s", subscription_id, sub.get("expirationDateTime"))
+            return sub
+        else:
+            logger.error("Graph subscription renewal failed (%d): %s", resp.status_code, resp.text[:300])
+            return None
+
+    except Exception as e:
+        logger.exception("Graph subscription renewal error: %s", e)
+        return None
+
+
+def delete_subscription(subscription_id: str) -> bool:
+    """
+    Delete a Graph subscription (stop receiving notifications).
+
+    Args:
+        subscription_id: The Graph subscription ID to delete
+
+    Returns:
+        True if deleted successfully
+    """
+    token = _get_token()
+    if not token:
+        return False
+
+    try:
+        resp = requests.delete(
+            f"{GRAPH_BASE_URL}/subscriptions/{subscription_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+
+        if resp.status_code == 204:
+            logger.info("Graph subscription deleted: %s", subscription_id)
+            return True
+        else:
+            logger.error("Graph subscription delete failed (%d): %s", resp.status_code, resp.text[:300])
+            return False
+
+    except Exception as e:
+        logger.exception("Graph subscription delete error: %s", e)
+        return False
+
+
+def get_subscription(subscription_id: str) -> Optional[dict]:
+    """Get the current state of a Graph subscription."""
+    token = _get_token()
+    if not token:
+        return None
+
+    try:
+        resp = requests.get(
+            f"{GRAPH_BASE_URL}/subscriptions/{subscription_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+        return None
+    except Exception:
+        return None
+
+
+def needs_renewal(expiration_str: str) -> bool:
+    """Check if a subscription needs renewal (less than RENEWAL_THRESHOLD_MINUTES remaining)."""
+    try:
+        expiry = datetime.fromisoformat(expiration_str.replace("Z", "+00:00"))
+        remaining = (expiry - datetime.now(timezone.utc)).total_seconds() / 60
+        return remaining < RENEWAL_THRESHOLD_MINUTES
+    except Exception:
+        return True  # If we can't parse, renew to be safe
+
+
+def _get_token() -> Optional[str]:
+    """Get a Graph API access token using client credentials."""
+    tenant_id = os.environ.get("MS_GRAPH_TENANT_ID", "")
+    client_id = os.environ.get("MS_GRAPH_CLIENT_ID", "")
+    client_secret = os.environ.get("MS_GRAPH_CLIENT_SECRET", "")
+
+    if not client_id:
+        logger.error("Graph API not configured — MS_GRAPH_CLIENT_ID missing")
+        return None
+
+    try:
+        app = msal.ConfidentialClientApplication(
+            client_id,
+            authority=f"https://login.microsoftonline.com/{tenant_id}",
+            client_credential=client_secret,
+        )
+        result = app.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
+        return result.get("access_token")
+    except Exception as e:
+        logger.exception("Graph auth error: %s", e)
+        return None
+
+
+def _resolve_folder_id(token: str, user_email: str, folder_name: str) -> Optional[str]:
+    """Look up a Graph mail folder ID by name."""
+    try:
+        resp = requests.get(
+            f"{GRAPH_BASE_URL}/users/{user_email}/mailFolders",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"$select": "id,displayName"},
+        )
+        if resp.status_code == 200:
+            for folder in resp.json().get("value", []):
+                if folder.get("displayName", "").lower() == folder_name.lower():
+                    return folder["id"]
+    except Exception as e:
+        logger.error("Failed to resolve folder '%s': %s", folder_name, e)
+    return None


### PR DESCRIPTION
Closes #133

## Summary
- **Webhook endpoint** (`POST /api/webhooks/graph`) — handles Graph validation + change notifications
- **Subscription service** — create, renew (before 3-day expiry), delete, status check
- **Admin API** — `POST/GET/DELETE /api/admin/graph/subscribe`, `POST /api/admin/graph/renew`
- **Immediate ingestion** — on notification, fetches the specific message and ingests it (no full mailbox scan)
- **Security** — validates clientState token, applies recipient filter, rejects spoofed notifications
- Falls back to polling when webhook not configured

## Setup
```
GRAPH_WEBHOOK_URL=https://your-app.onrender.com/api/webhooks/graph
GRAPH_WEBHOOK_SECRET=your-secret-token
```

## Test plan
- [ ] `POST /api/admin/graph/subscribe` creates a subscription (requires public URL)
- [ ] `GET /api/admin/graph/subscribe` shows subscription status
- [ ] New email → Graph sends notification → message appears in Golteris within seconds
- [ ] `DELETE /api/admin/graph/subscribe` removes subscription
- [ ] Without GRAPH_WEBHOOK_URL → returns helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)